### PR TITLE
feat: add Claude Code guardrails configuration 🤖

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help bin-version-check bin-paths-check all-checks
+.PHONY: help install-claude bin-version-check bin-paths-check all-checks
 
 # Default target
 .DEFAULT_GOAL := help
@@ -20,6 +20,9 @@ COLOR_BLUE=\033[36m
 
 help: ## Display this help message
 	@echo "🔧 AVAILABLE TARGETS:"
+	@echo ""
+	@echo "📦 INSTALL:"
+	@grep -E '^install-.*:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(COLOR_BLUE)%-25s$(COLOR_RESET) %s\n", $$1, $$2}'
 	@echo ""
 	@echo "✅ VALIDATION:"
 	@grep -E '^(bin-version-check|bin-paths-check|all-checks):.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(COLOR_BLUE)%-25s$(COLOR_RESET) %s\n", $$1, $$2}'
@@ -148,6 +151,14 @@ bin-paths-check: ## Verify all required binaries are in PATH
 		printf "$(COLOR_YELLOW)💡 Ensure ~/bin is in your PATH and binaries are installed$(COLOR_RESET)\n"; \
 		exit 1; \
 	fi
+
+install-claude: ## Symlink Claude Code configuration to ~/.claude
+	@echo "🔧 Installing Claude Code configuration..."
+	@mkdir -p ~/.claude
+	@ln -sf $(CURDIR)/claude/CLAUDE.md ~/.claude/CLAUDE.md
+	@ln -sf $(CURDIR)/claude/settings.json ~/.claude/settings.json
+	@ln -sfn $(CURDIR)/claude/hooks ~/.claude/hooks
+	@printf "$(COLOR_GREEN)✅ Claude Code configuration linked to ~/.claude$(COLOR_RESET)\n"
 
 all-checks: bin-paths-check bin-version-check ## Run all validation checks
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Personal configuration files for shell and tools.
 - `zsh/git.zsh`, git shortcuts and functions
 - `zsh/kubectl.zsh`, kubernetes kubectl shortcuts
 - `completions/`, zsh completion scripts
+- `claude/`, Claude Code configuration (CLAUDE.md, settings.json, hooks)
 
 # ZSH Plugins
 
@@ -27,6 +28,8 @@ Personal configuration files for shell and tools.
 - `oh-my-zsh`, framework
 - `tmux`, terminal multiplexer (auto-starts with zsh)
 - `kubectl`, for kubernetes features
+- `jq`, required by Claude Code hook scripts
+- `gh`, GitHub CLI, required by Claude Code co-author policy hook
 
 # External Tools
 
@@ -62,6 +65,12 @@ ln -sf ~/path/to/dotfiles/zsh/aliases.zsh ~/.config/zsh/aliases.zsh
 ln -sf ~/path/to/dotfiles/zsh/git.zsh ~/.config/zsh/git.zsh
 ln -sf ~/path/to/dotfiles/zsh/kubectl.zsh ~/.config/zsh/kubectl.zsh
 ln -sf ~/path/to/dotfiles/completions ~/.config/zsh/completions
+```
+
+- Claude Code configuration:
+
+```
+make install-claude
 ```
 
 - Reload shell:

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,0 +1,26 @@
+# Prime Directives
+
+IMPORTANT: These rules are NON-NEGOTIABLE.
+
+## Behavior
+- Defense in Depth — nothing is completed until verified working
+- NEVER say "you're right" — no reflexive agreement
+- CHALLENGE incorrect user statements with evidence
+- If you don't know, say so — no hallucination assumptions
+- Read docs BEFORE attempting commands — never assume how tools work
+- Ask more questions, make fewer assumptions
+
+## Git
+- NEVER push to "main" or default branch — NO EXCEPTIONS
+- NEVER create "master" branch
+- Signed commits (`--gpg-sign`) required
+- Branch naming: `<type>/<issue>-<description>`
+- Branch types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `security`, `spike`
+- Base branch: main | Merge style: merge commit | Delete branch after merge
+- Use `Refs #N` in commits — NEVER `Closes #N` (closing is a merge-time decision)
+
+## PR Workflow
+- IMPORTANT: Draft PRs by default — ALWAYS use `--draft`
+- IMPORTANT: After creating a PR, STOP. Provide the PR URL. Do NOT suggest merging.
+- NEVER run `gh pr merge` or `gh pr ready` — merging is a human decision after peer review
+- CI passing does NOT mean ready to merge

--- a/claude/hooks/no-closes-in-commits.sh
+++ b/claude/hooks/no-closes-in-commits.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [[ "$TOOL" == "Bash" ]] && echo "$COMMAND" | grep -qi 'git commit'; then
+  if echo "$COMMAND" | grep -qiE '(Closes|Fixes|Resolves) #[0-9]+'; then
+    jq -n '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Use \"Refs #N\" instead of \"Closes #N\" in commit messages. Closing issues is a merge-time decision after peer review."
+      }
+    }'
+    exit 0
+  fi
+fi
+exit 0

--- a/claude/hooks/no-closes-in-pr-body.sh
+++ b/claude/hooks/no-closes-in-pr-body.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [[ "$TOOL" == "Bash" ]] && echo "$COMMAND" | grep -qi 'gh pr create'; then
+  if echo "$COMMAND" | grep -qiE '(Closes|Fixes|Resolves) #[0-9]+'; then
+    jq -n '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Use \"Refs #N\" or \"Part of #N\" instead of \"Closes #N\" in PR bodies. Closing issues is a merge-time decision after peer review."
+      }
+    }'
+    exit 0
+  fi
+fi
+exit 0

--- a/claude/hooks/no-coauthor-private.sh
+++ b/claude/hooks/no-coauthor-private.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [[ "$TOOL" == "Bash" ]] && echo "$COMMAND" | grep -qi 'git commit'; then
+  if echo "$COMMAND" | grep -qi 'Co-Authored-By'; then
+    IS_PRIVATE=$(gh repo view --json isPrivate -q '.isPrivate' 2>/dev/null || echo "unknown")
+    if [[ "$IS_PRIVATE" == "true" || "$IS_PRIVATE" == "unknown" ]]; then
+      jq -n '{
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason: "NO Claude co-author on private or visibility-unknown repos. Remove the Co-Authored-By line."
+        }
+      }'
+      exit 0
+    fi
+  fi
+fi
+exit 0

--- a/claude/hooks/no-push-to-main.sh
+++ b/claude/hooks/no-push-to-main.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [[ "$TOOL" == "Bash" ]] && echo "$COMMAND" | grep -qi 'git push'; then
+  if echo "$COMMAND" | grep -qiE 'git push.*(origin|upstream)\s+(main|master)\b'; then
+    jq -n '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "NEVER push to main or master. Push to a feature branch instead."
+      }
+    }'
+    exit 0
+  fi
+fi
+exit 0

--- a/claude/hooks/require-signed-commits.sh
+++ b/claude/hooks/require-signed-commits.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [[ "$TOOL" == "Bash" ]] && echo "$COMMAND" | grep -qi 'git commit'; then
+  if ! echo "$COMMAND" | grep -qE '(--gpg-sign|-S)'; then
+    jq -n '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "All commits MUST be signed. Add --gpg-sign flag to git commit."
+      }
+    }'
+    exit 0
+  fi
+fi
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,0 +1,61 @@
+{
+  "alwaysThinkingEnabled": true,
+  "permissions": {
+    "deny": [
+      "Bash(gh pr merge *)",
+      "Bash(gh pr ready *)",
+      "Bash(git push origin main)",
+      "Bash(git push origin main *)",
+      "Bash(git push --force *)",
+      "Bash(git push * --force)",
+      "Bash(git reset --hard *)",
+      "Bash(git checkout -- .)",
+      "Bash(git clean -f *)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/no-closes-in-commits.sh",
+            "statusMessage": "Checking commit message conventions"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/no-push-to-main.sh",
+            "statusMessage": "Checking push target"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/no-closes-in-pr-body.sh",
+            "statusMessage": "Checking PR body conventions"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/require-signed-commits.sh",
+            "statusMessage": "Checking commit signing"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/no-coauthor-private.sh",
+            "statusMessage": "Checking co-author policy"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Check if the assistant just created or modified a pull request. If so, verify: (1) It was created as a DRAFT PR (--draft flag), (2) The assistant did NOT suggest merging or mark it ready, (3) The assistant's final message tells the user the PR URL and stops — it does NOT suggest next steps about merging. If any of these are violated, return {\"ok\": false, \"reason\": \"PR must be draft. Never suggest merging. Stop after providing PR URL.\"}. $ARGUMENTS",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Add `claude/` directory with CLAUDE.md, settings.json, and 5 PreToolUse hook scripts
- Hook scripts enforce: signed commits, no push to main, no auto-closing issues, no co-author on private repos
- Add `make install-claude` target to symlink configuration to `~/.claude`
- Update README with Files, Requirements, and Setup sections for Claude Code

## Details

**Files added:**
- `claude/CLAUDE.md` — behavioral rules (git workflow, PR conventions)
- `claude/settings.json` — permission deny rules + hook definitions
- `claude/hooks/` — 5 bash scripts (require `jq`, `gh`)

**Makefile:**
- New `install-claude` target using `$(CURDIR)` for portable symlinks

**Post-merge:** Run `make install-claude` to activate (symlinks `claude/` → `~/.claude/`)

Refs #2