### PR TITLE
fix(hooks): add grep double-dash to prevent --flag misparse 🐛

### DIFF
--- a/claude/hooks/helm-version-required.sh
+++ b/claude/hooks/helm-version-required.sh
@@ -4,8 +4,8 @@ INPUT=$(cat)
 TOOL=$(echo "$INPUT" | jq -r '.tool_name')
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
-if [[ "$TOOL" == "Bash" ]] && echo "$COMMAND" | grep -qE '^\s*helm\s+(upgrade|install)\b'; then
-  if ! echo "$COMMAND" | grep -qE '--version[ =]'; then
+if [[ "$TOOL" == "Bash" ]] && echo "$COMMAND" | grep -qE '^[[:space:]]*helm[[:space:]]+(upgrade|install)($|[[:space:]])'; then
+  if ! echo "$COMMAND" | grep -qE -- '--version[ =]'; then
     jq -n '{
       hookSpecificOutput: {
         hookEventName: "PreToolUse",

--- a/claude/hooks/kubectl-context-required.sh
+++ b/claude/hooks/kubectl-context-required.sh
@@ -4,8 +4,8 @@ INPUT=$(cat)
 TOOL=$(echo "$INPUT" | jq -r '.tool_name')
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
-if [[ "$TOOL" == "Bash" ]] && echo "$COMMAND" | grep -qE '^\s*kubectl\s+(apply|delete|patch|edit|create|replace|scale|drain|cordon|uncordon|exec|rollout|label|annotate|taint)\b'; then
-  if ! echo "$COMMAND" | grep -qE '--context[ =]'; then
+if [[ "$TOOL" == "Bash" ]] && echo "$COMMAND" | grep -qE '^[[:space:]]*kubectl[[:space:]]+(apply|delete|patch|edit|create|replace|scale|drain|cordon|uncordon|exec|rollout|label|annotate|taint)($|[[:space:]])'; then
+  if ! echo "$COMMAND" | grep -qE -- '--context[ =]'; then
     jq -n '{
       hookSpecificOutput: {
         hookEventName: "PreToolUse",


### PR DESCRIPTION
## Summary

- Both `kubectl-context-required.sh` and `helm-version-required.sh` hooks had a grep bug: `grep -qE '--flag[ =]'` causes grep to interpret `--context` / `--version` as its own command-line options, not regex patterns
- Add `--` (end-of-options) separator before the pattern so grep treats them as literal regex
- Without this fix, hooks deny ALL mutating commands — even those with the required flag present

Refs #10, #11

## Test plan

- [x] kubectl deny (no `--context`): outputs deny JSON
- [x] kubectl allow (`--context dev`): silent exit 0
- [x] kubectl allow (`--context=dev`): silent exit 0
- [x] kubectl ignore (read-only `get pods`): silent exit 0
- [x] helm deny (no `--version`): outputs deny JSON
- [x] helm allow (`--version 1.2.3`): silent exit 0
- [x] helm allow (`--version=1.2.3`): silent exit 0
- [x] helm deny (`install` no `--version`): outputs deny JSON
