### PR TITLE
feat(skills): add Autonity CLI (`aut`) tool skill 🎓

### DIFF
--- a/claude/skills/autonity-cli/SKILL.md
+++ b/claude/skills/autonity-cli/SKILL.md
@@ -11,7 +11,7 @@ description: >-
 
 ## Configuration & Environment
 
-`.autrc` is an INI-style config file. Search order: current directory → parent directories → `~/.config/aut/autrc`.
+`.autrc` is an INI-style config file. Search order: current directory → parent directories → `~/.config/aut/autrc`. Note: the global config filename is `autrc` (no leading dot) — this is intentional XDG convention; only the local/project file uses `.autrc`.
 
 Key config fields:
 


### PR DESCRIPTION
## Summary

- Adds `claude/skills/autonity-cli/SKILL.md` (206 lines) with YAML frontmatter
- Covers the operator-facing `aut` CLI: config, tx pipeline, account management, staking, contract interaction, protocol queries, denominations, scripting patterns
- 13 anti-patterns flagged (key/password leakage, gas flag conflicts, ignoring tx wait exit codes, etc.)
- No overlap with existing `autonity`, `autonity-sdk`, or `autonity-defi` skills — those cover protocol/SDK/DeFi; this covers the CLI tool itself
- Auto-discovered by existing `make install-claude` symlink target — no Makefile changes

## Verification

- [x] `cat ~/.claude/skills/autonity-cli/SKILL.md` succeeds (symlink via `make install-claude`)
- [x] Frontmatter `name: autonity-cli` matches directory name
- [x] `description` covers: what tool, what commands, when to use
- [x] Anti-patterns section has 13 items (≥12 required)
- [x] No overlap with `autonity`, `autonity-sdk`, `autonity-defi` skills
- [x] Signed commit, `Refs #48`, draft PR

Refs #48