### PR TITLE
feat(skills): add Matrix/mautrix-go/Tuwunel E2EE skill 🎓

### DIFF
--- a/claude/skills/matrix/SKILL.md
+++ b/claude/skills/matrix/SKILL.md
@@ -53,8 +53,9 @@ func main() {
         log.Fatal().Err(err).Msg("matrix client init failed")
     }
 
-    // Pass Postgres DSN or SQLite file path — both supported natively
-    helper, err := cryptohelper.NewCryptoHelper(cli, pickleKey, "postgres://user:pass@host/botdb")
+    // Pass Postgres DSN or SQLite file path — both supported natively.
+    // Never inline credentials — read DSN from an environment variable or secret manager.
+    helper, err := cryptohelper.NewCryptoHelper(cli, pickleKey, os.Getenv("MATRIX_DB_DSN"))
     if err != nil {
         log.Fatal().Err(err).Msg("crypto helper init failed")
     }
@@ -72,13 +73,12 @@ func main() {
     }
     cli.Crypto = helper  // enables auto-encrypt on send, auto-decrypt on receive
 
-    // ... continued in Event Handling and Sync Loop below
-}
+    // ... continued in Event Handling and Sync Loop below — do not close func main() here
 ```
 
 ### Event Handling and Sync Loop
 
-Continues inside `func main()` after the crypto setup above.
+This snippet is the direct continuation of `func main()` above. In practice both sections form a single function; they are split here for readability.
 
 ```go
     syncer, ok := cli.Syncer.(*mautrix.DefaultSyncer)
@@ -193,10 +193,12 @@ All admin commands are sent as messages in the `#admins:example.com` room.
 
 ### Appservice Registration
 
-Send `appservice_register` in the admin room, followed immediately by a YAML code block:
+Send `appservice_register` as a plain message in the admin room, then immediately follow it with a separate YAML code block message:
 
-````
+```text
 appservice_register
+```
+
 ```yaml
 id: "voice-bot"
 url: "http://voice-bot.default.svc.cluster.local:8080"
@@ -210,7 +212,6 @@ namespaces:
   aliases: []
   rooms: []
 ```
-````
 
 Verify with `appservice_list`.
 


### PR DESCRIPTION
## Summary

- Adds `claude/skills/matrix/SKILL.md` (214 lines) with YAML frontmatter
- Covers: Matrix room model + E2EE fundamentals (olm/megolm), mautrix-go bot lifecycle with Go code patterns, `SQLCryptoStore` + PostgreSQL persistence, Tuwunel TOML config and admin room commands (verified from `matrix-construct/tuwunel` source), E2EE bootstrap ceremony, `self_sign` requirement (April 2026 deadline)
- 8 anti-patterns (MemoryStore, concurrent instances, appservice E2EE on non-Synapse, shared DB, pickle_key corruption, missing self_sign, post-creation E2EE, client-only self-filter)
- All Tuwunel config keys and admin commands verified from `src/core/config/mod.rs` and `src/admin/*/commands.rs` — no guessing
- Build tag `-tags goolm` (pure Go, no CGo) documented for static K8s binaries
- Auto-discovered by existing `make install-claude` symlink target — no Makefile changes needed

## Verification

- [x] `cat ~/.claude/skills/matrix/SKILL.md` succeeds (symlink via `make install-claude`)
- [x] Frontmatter `name: matrix` matches directory name
- [x] Trigger keywords in description: `matrix`, `mautrix`, `tuwunel`, `E2EE`, `olm`
- [x] mautrix-go lifecycle with exact Go types (`mautrix.Client`, `cryptohelper.CryptoHelper`, `crypto.SQLCryptoStore`)
- [x] `-tags goolm` pure Go build documented
- [x] Tuwunel TOML key names verified from source (`server_name`, `database_path`, `address`, `port`, `allow_registration`, `registration_token`, `log`)
- [x] Env var prefix `TUWUNEL_` with `__` nesting verified from source
- [x] Admin room commands verified from source (`create_user`, `make_user_admin`, `appservice_register`, `token issue/revoke/list`)
- [x] `self_sign` requirement and April 2026 deadline documented
- [x] `pickle_key` K8s Secret injection pattern documented
- [x] PostgreSQL crypto table ownership rule documented
- [x] Anti-patterns section has 8 items
- [x] Signed commit, `Refs #52`, draft PR

Refs #52