### PR TITLE
fix(skills): correct Android skill gaps from deck-chat learnings 🎓

### DIFF
--- a/claude/skills/android/SKILL.md
+++ b/claude/skills/android/SKILL.md
@@ -155,7 +155,9 @@ class SherpaOnnxSttEngine(private val context: Context) : SttEngine {
     // Check for specific files (not just non-empty dir) to detect partial copies.
     private fun copyAssetsToDisk(): File {
         val destDir = File(context.filesDir, "stt")
-        if (destDir.exists() && File(destDir, "tiny.en-encoder.int8.onnx").length() > 0) return destDir
+        val encoderOk = File(destDir, "tiny.en-encoder.int8.onnx").let { it.exists() && it.length() > 0 }
+        val decoderOk = File(destDir, "tiny.en-decoder.int8.onnx").let { it.exists() && it.length() > 0 }
+        if (destDir.exists() && encoderOk && decoderOk) return destDir
         destDir.mkdirs()
         context.assets.list("stt")?.forEach { name ->
             context.assets.open("stt/$name").use { src ->
@@ -433,7 +435,7 @@ fastlane/metadata/android/
 name: CI
 on:
   push:
-    branches: [main]    # CI on merge to main
+    branches: [main]    # CI on push to main
   pull_request:          # CI on PRs — do NOT use [push, pull_request] (fires twice on PR branches)
 
 jobs:


### PR DESCRIPTION
## Summary

- Correct Sherpa-ONNX Maven coordinates: `com.github.k2-fsa:sherpa-onnx` via JitPack (not `sherpa-onnx-android` on Maven Central), version requires `v` prefix
- Add JitPack `content { includeGroup(...) }` pattern for supply-chain scoping
- Add `OfflineRecognizer` + `OfflineWhisperModelConfig` pattern for batch/offline STT
- Fix CI trigger from `[push, pull_request]` to scoped `push: { branches: [main] }`
- Add matrix-rust-sdk versioning note (Android bindings from `matrix-rust-components-kotlin`)
- Add version catalog hygiene section (`version.ref` consistency, `v` prefix, upstream verification)
- Add 3 new anti-patterns: duplicate CI trigger, unscoped JitPack, inline version duplication

All gaps discovered during deck-chat PR #11 (Sherpa-ONNX STT engine) development and verified against cloned upstream repos.

## Test plan

- [ ] Skill renders correctly in GitHub markdown
- [ ] All code examples are syntactically valid
- [ ] Anti-patterns section covers the three new entries
- [ ] No references to private repos or internal infrastructure

Refs #56
