### PR TITLE
feat(skills): add Android SDK provisioning section to Nix skill 🎓

### DIFF
--- a/claude/skills/nix/SKILL.md
+++ b/claude/skills/nix/SKILL.md
@@ -208,7 +208,7 @@ This ensures CI uses the exact same SDK and JDK versions as local development.
 Keep SDK versions consistent across all files:
 - `buildToolsVersions` / `platformVersions` in `flake.nix` and `devenv.nix`
 - `compileSdk` / `targetSdk` in `app/build.gradle.kts`
-- See the Android skill for Gradle-side configuration
+- See the [Android skill](../android/SKILL.md) for Gradle-side configuration
 
 ## Security
 


### PR DESCRIPTION
## Summary

- Add Android SDK provisioning section to the Nix skill covering `androidenv.composeAndroidPackages`
- Document unfree/license acceptance patterns for both `flake.nix` and `devenv.nix`
- Show `ANDROID_HOME` / `ANDROID_SDK_ROOT` environment variable setup
- Document GitHub Actions CI integration using `nix develop --command` (replaces `actions/setup-java` + `android-actions/setup-android`)
- Add version alignment guidance between Nix SDK config and Gradle `compileSdk`/`targetSdk`
- Update skill description to mention Android SDK provisioning

All patterns verified from deck-chat project (`klazomenai/deck-chat` `flake.nix` + `devenv.nix`).

## Test plan

- [ ] Skill renders correctly in GitHub markdown
- [ ] All Nix code examples are syntactically valid
- [ ] YAML CI example is valid GitHub Actions syntax
- [ ] Cross-reference to Android skill is accurate

Refs #57
