### PR TITLE
feat(skills): add matrix-rust-sdk Kotlin patterns to Android skill 🎓

### DIFF
--- a/claude/skills/android/SKILL.md
+++ b/claude/skills/android/SKILL.md
@@ -280,9 +280,9 @@ val client = ClientBuilder()
     .homeserverUrl(savedHomeserverUrl)
     .slidingSyncVersionBuilder(SlidingSyncVersionBuilder.DISCOVER_NATIVE)
     .sessionPaths(dataDir.absolutePath, cacheDir.absolutePath)
-    .build()
+    .build()  // suspend
 
-client.restoreSession(savedSession)  // suspend — run in coroutine scope
+client.restoreSession(savedSession)  // suspend
 ```
 
 Store `Session` fields in `EncryptedSharedPreferences` / Android Keystore (see Keystore section below). The SQLite store at `sessionPaths` persists E2EE keys — do NOT delete it between restarts.


### PR DESCRIPTION
## Summary

- Expanded Matrix Client section from 3 bullet points to full API reference with code examples
- ClientBuilder + login + session restore patterns with exact Kotlin API signatures
- SyncService + TimelineListener for Sliding Sync message delivery
- Message extraction chain: TimelineDiff → TimelineItem → EventTimelineItem → MsgLikeKind.Message → MessageType.Text → body
- Room.sendRaw for sending with custom event fields
- Custom event fields limitation documented (typed API strips custom JSON, body-prefix workaround)
- ProGuard rules for JNA + UniFFI (SDK consumer-rules.pro is empty)
- JVM heap/metaspace settings for large UniFFI-generated Kotlin (gradle.properties)
- 4 new anti-patterns: /sync v2 assumption, custom fields via typed API, missing ProGuard rules, deleting sessionPaths
- Cross-reference to Matrix skill for protocol/E2EE concepts
- Updated skill description frontmatter

All patterns verified from deck-chat PR #48 (Matrix client implementation) and the cloned `matrix-org/matrix-rust-components-kotlin` generated Kotlin source.

## Test plan

- [x] Skill renders correctly in GitHub markdown
- [x] All Kotlin code examples are syntactically valid
- [x] Anti-patterns section covers 4 new entries
- [x] Cross-reference link to Matrix skill works

Refs #60
