### PR TITLE
🎓 docs(android): add Sliding Sync readiness patterns and bug fixes

### DIFF
--- a/claude/skills/android/SKILL.md
+++ b/claude/skills/android/SKILL.md
@@ -360,6 +360,8 @@ When the interface contract doesn't support async readiness (e.g. existing `Matr
 
 ```kotlin
 import kotlinx.coroutines.delay
+import org.matrix.rustcomponents.sdk.Client
+import org.matrix.rustcomponents.sdk.Room
 
 suspend fun awaitRoom(client: Client, roomId: String): Room {
     val delays = longArrayOf(100, 200, 500, 1000, 2000, 5000)

--- a/claude/skills/android/SKILL.md
+++ b/claude/skills/android/SKILL.md
@@ -152,13 +152,14 @@ class SherpaOnnxSttEngine(private val context: Context) : SttEngine {
     private val recognizer: OfflineRecognizer
         get() = recognizerInstance ?: createRecognizer().also { recognizerInstance = it }
 
-    // Copy ONNX models from assets/ to filesDir/ (JNI needs file-system paths).
+    // Copy ONNX models + tokens from assets/ to filesDir/ (JNI needs file-system paths).
     // Check for specific files (not just non-empty dir) to detect partial copies.
     private fun copyAssetsToDisk(): File {
         val destDir = File(context.filesDir, "stt")
         val encoderOk = File(destDir, "tiny.en-encoder.int8.onnx").let { it.exists() && it.length() > 0 }
         val decoderOk = File(destDir, "tiny.en-decoder.int8.onnx").let { it.exists() && it.length() > 0 }
-        if (destDir.exists() && encoderOk && decoderOk) return destDir
+        val tokensOk = File(destDir, "tiny.en-tokens.txt").let { it.exists() && it.length() > 0 }
+        if (destDir.exists() && encoderOk && decoderOk && tokensOk) return destDir
         destDir.mkdirs()
         context.assets.list("stt")?.forEach { name ->
             context.assets.open("stt/$name").use { src ->
@@ -297,7 +298,9 @@ Store `Session` fields in `EncryptedSharedPreferences` / Android Keystore (see K
 val syncService = client.syncService().finish()
 syncService.start()  // suspend — begins background sync
 
-// Listen to a room's timeline
+// IMPORTANT: getRoom() returns null until Sliding Sync delivers the room.
+// Wait for RoomListServiceState.RUNNING or use retry with backoff.
+// See "Sliding Sync Readiness" section below.
 val room = client.getRoom(roomId) ?: error("Room not found")
 val timeline = room.timeline()  // suspend
 
@@ -354,20 +357,26 @@ val stateHandle = roomListService.state(object : RoomListServiceStateListener {
 
 **Pragmatic alternative — retry with backoff:**
 
-When the interface contract doesn't support async readiness (e.g. existing `MatrixClient` abstraction), retry `getRoom()` with exponential backoff:
+When the interface contract doesn't support async readiness (e.g. existing `MatrixClient` abstraction), retry `getRoom()` with exponential backoff. Must run in a coroutine context (`delay` is a suspend function):
 
 ```kotlin
-var room: Room? = null
-val delays = longArrayOf(100, 200, 500, 1000, 2000, 5000)
-for (attempt in delays.indices) {
-    room = client.getRoom(roomId)
-    if (room != null) break
-    if (attempt < delays.lastIndex) delay(delays[attempt])
+import kotlinx.coroutines.delay
+
+suspend fun awaitRoom(client: Client, roomId: String): Room {
+    val delays = longArrayOf(100, 200, 500, 1000, 2000, 5000)
+    for (attempt in delays.indices) {
+        val room = client.getRoom(roomId)
+        if (room != null) return room
+        if (attempt < delays.lastIndex) {
+            Log.d(TAG, "Room not yet available, retrying in ${delays[attempt]}ms")
+            delay(delays[attempt])
+        }
+    }
+    throw IllegalArgumentException("Room not found after ${delays.size} attempts: $roomId")
 }
-if (room == null) throw IllegalArgumentException("Room not found after retries: $roomId")
 ```
 
-Total max wait: ~8.8 seconds. Typically succeeds on first or second attempt (~100-300ms). Log each retry so the user sees progress.
+Total max wait: ~3.8 seconds (100+200+500+1000+2000; final attempt has no delay). Typically succeeds on first or second attempt (~100-300ms). Log each retry so the user sees progress.
 
 ### Message Extraction
 

--- a/claude/skills/android/SKILL.md
+++ b/claude/skills/android/SKILL.md
@@ -179,6 +179,9 @@ class SherpaOnnxSttEngine(private val context: Context) : SttEngine {
                     language = "en",
                     task = "transcribe",
                 ),
+                // tokens is REQUIRED — validation fails silently (returns null
+                // pointer) without it, causing SIGSEGV on createStream().
+                tokens = "$sttDir/tiny.en-tokens.txt",
                 numThreads = 2, debug = false, provider = "cpu",
             ),
         )
@@ -316,6 +319,56 @@ syncService.stop()
 handle.close()
 ```
 
+### Sliding Sync Readiness
+
+`client.getRoom(roomId)` returns **null before Sliding Sync delivers rooms**. After `login()` or `restoreSession()`, the state store is empty. Rooms are populated asynchronously by the `SyncService` background loop. Calling `getRoom()` immediately after `syncService.start()` is a race condition.
+
+**Callback interfaces for sync state observation:**
+
+| Interface | States | When rooms are available |
+|-----------|--------|------------------------|
+| `SyncServiceStateObserver` | `IDLE`, `RUNNING`, `TERMINATED`, `ERROR`, `OFFLINE` | After `RUNNING` |
+| `RoomListServiceStateListener` | `INITIAL`, `SETTING_UP`, `RECOVERING`, `RUNNING`, `ERROR`, `TERMINATED` | After `RUNNING` |
+| `RoomListLoadingStateListener` | `NotLoaded`, `Loaded(maximumNumberOfRooms)` | After `Loaded` |
+
+**Correct pattern — observe room list state before `getRoom()`:**
+
+```kotlin
+import org.matrix.rustcomponents.sdk.RoomListServiceState
+import org.matrix.rustcomponents.sdk.RoomListServiceStateListener
+
+val syncService = client.syncService().finish()
+syncService.start()
+
+// Observe room list readiness
+val roomListService = syncService.roomListService()
+val stateHandle = roomListService.state(object : RoomListServiceStateListener {
+    override fun onUpdate(state: RoomListServiceState) {
+        if (state == RoomListServiceState.RUNNING) {
+            // Rooms are now available — safe to call getRoom()
+        }
+    }
+})
+// Keep stateHandle alive; call stateHandle.cancel() on cleanup
+```
+
+**Pragmatic alternative — retry with backoff:**
+
+When the interface contract doesn't support async readiness (e.g. existing `MatrixClient` abstraction), retry `getRoom()` with exponential backoff:
+
+```kotlin
+var room: Room? = null
+val delays = longArrayOf(100, 200, 500, 1000, 2000, 5000)
+for (attempt in delays.indices) {
+    room = client.getRoom(roomId)
+    if (room != null) break
+    if (attempt < delays.lastIndex) delay(delays[attempt])
+}
+if (room == null) throw IllegalArgumentException("Room not found after retries: $roomId")
+```
+
+Total max wait: ~8.8 seconds. Typically succeeds on first or second attempt (~100-300ms). Log each retry so the user sees progress.
+
 ### Message Extraction
 
 ```kotlin
@@ -357,12 +410,18 @@ Parse with a regex on the receiving side. Proper raw event access is a future im
 The SDK uses JNA for the native bridge. Its `consumer-rules.pro` is empty — add these to the app's `proguard-rules.pro`:
 
 ```
--keep class net.java.dev.jna.** { *; }
+# JNA — transitive dependency of org.matrix.rustcomponents:sdk-android.
+# Package is com.sun.jna (NOT net.java.dev.jna — that's the Maven group ID).
+-keep class com.sun.jna.** { *; }
 -keep class org.matrix.rustcomponents.sdk.** { *; }
 -keep class uniffi.** { *; }
+
+# JNA's Native$AWT references java.awt classes not available on Android.
+# These code paths are never reached (JNA detects Android at runtime).
+-dontwarn java.awt.**
 ```
 
-Also keep any app classes implementing SDK callback interfaces (`TimelineListener`, `SyncServiceStateObserver`, etc.).
+Also keep any app classes implementing SDK callback interfaces (`TimelineListener`, `SyncServiceStateObserver`, `RoomListServiceStateListener`, etc.).
 
 ### JVM Heap for Large SDKs
 
@@ -601,5 +660,7 @@ Unit tests run on the JVM and must not invoke JNI — mock all native engines vi
 - **Inline `version = "x.y.z"` in version catalog** — duplicates the version with the `[versions]` section. Always use `version.ref`.
 - **Assuming `/sync` v2 availability** — matrix-rust-sdk FFI only exposes Sliding Sync via `SyncService`. Do not attempt to call `Client.sync()` or use traditional sync endpoints.
 - **Custom event fields via typed SDK API** — `TextMessageContent` strips custom JSON fields during Rust→Kotlin conversion. Use `Room.sendRaw()` for sending custom fields and body-prefix convention for receiving.
-- **Missing ProGuard rules for JNA/UniFFI** — release builds crash without keep rules for `net.java.dev.jna.**`, `org.matrix.rustcomponents.sdk.**`, `uniffi.**`. The SDK's `consumer-rules.pro` is empty.
+- **Missing ProGuard rules for JNA/UniFFI** — release builds crash without keep rules for `com.sun.jna.**` (NOT `net.java.dev.jna.**` — that's the Maven group ID), `org.matrix.rustcomponents.sdk.**`, `uniffi.**`. Also needs `-dontwarn java.awt.**` for JNA's desktop AWT refs. The SDK's `consumer-rules.pro` is empty.
 - **Deleting `sessionPaths` SQLite store** — the store persists E2EE keys (Olm sessions, Megolm keys). Deleting it loses all encryption state and requires full session reset.
+- **Calling `getRoom()` before Sliding Sync delivers rooms** — returns null immediately after `login()` or `restoreSession()`. Wait for `RoomListServiceState.RUNNING` or use retry with backoff. See "Sliding Sync Readiness" section.
+- **Missing Whisper tokens file** — `OfflineModelConfig.tokens` must point to `tiny.en-tokens.txt`. Without it, `OfflineRecognizer` native constructor returns null (0) and `createStream()` dereferences it → SIGSEGV. Validation fails silently at `offline-model-config.cc:101-106`.

--- a/claude/skills/android/SKILL.md
+++ b/claude/skills/android/SKILL.md
@@ -299,9 +299,8 @@ val syncService = client.syncService().finish()
 syncService.start()  // suspend — begins background sync
 
 // IMPORTANT: getRoom() returns null until Sliding Sync delivers the room.
-// Wait for RoomListServiceState.RUNNING or use retry with backoff.
-// See "Sliding Sync Readiness" section below.
-val room = client.getRoom(roomId) ?: error("Room not found")
+// Use retry with backoff — see "Sliding Sync Readiness" section below.
+val room = awaitRoom(client, roomId)
 val timeline = room.timeline()  // suspend
 
 val handle = timeline.addListener(object : TimelineListener {
@@ -368,7 +367,7 @@ suspend fun awaitRoom(client: Client, roomId: String): Room {
         val room = client.getRoom(roomId)
         if (room != null) return room
         if (attempt < delays.lastIndex) {
-            Log.d(TAG, "Room not yet available, retrying in ${delays[attempt]}ms")
+            // Log retry attempts so the user sees progress
             delay(delays[attempt])
         }
     }


### PR DESCRIPTION
## Summary

Update the Android skill with lessons learned from deck-chat M1 development (2026-04-01 to 2026-04-03). Four changes:

### A. Sliding Sync Readiness (NEW section)
- Document that `getRoom()` returns null before initial sync
- `SyncServiceStateObserver`, `RoomListServiceStateListener`, `RoomListLoadingStateListener` callback interfaces
- Correct wait pattern and retry-with-backoff alternative
- Source: `matrix-org/matrix-rust-sdk` FFI bindings

### B. ProGuard Rules Fix
- `com.sun.jna.**` (Java package) not `net.java.dev.jna.**` (Maven group ID)
- Add `-dontwarn java.awt.**` for JNA desktop AWT refs
- Source: deck-chat #118, #122

### C. Whisper Tokens File
- Add `tokens` path to `OfflineModelConfig` example
- Document silent null pointer failure without it
- Source: deck-chat #133, sherpa-onnx `offline-model-config.cc:101-106`

### D. New Anti-patterns
- `getRoom()` before sync delivers rooms
- Missing Whisper tokens file → SIGSEGV

## Test plan

- [x] Skill renders correctly (no broken markdown)
- [x] `make install-claude` symlinks updated skill

Refs #72
