### PR TITLE
feat(hooks): add PreToolUse hook to prevent git rebase 🔐

### DIFF
--- a/claude/hooks/no-rebase.sh
+++ b/claude/hooks/no-rebase.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+# Normalize backslash-newline continuations.
+COMMAND="${COMMAND//$'\\\n'/}"
+
+if [[ "$TOOL" != "Bash" ]]; then
+  exit 0
+fi
+
+# Detect 'git rebase' with shell-boundary anchoring to avoid matching
+# quoted strings like 'echo "git rebase"'. Recognises common prefixes:
+# sudo, command, exec, env, and inline VAR=val assignments.
+if echo "$COMMAND" | grep -qE '(^|[;|&({])[[:space:]]*((sudo|command|exec)[[:space:]]+|(env[[:space:]]+)?([A-Z_][A-Z0-9_]*=[^[:space:]]*[[:space:]]+)*)?git([[:space:]]+(-[Cc][[:space:]]+[^[:space:]]+|-[^[:space:]]*))*[[:space:]]+rebase($|[^a-zA-Z0-9_-])'; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "NEVER rebase — it rewrites history and requires force-push. Use git merge instead."
+    }
+  }'
+  exit 0
+fi
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -11,6 +11,7 @@
       "Bash(git reset --hard *)",
       "Bash(git checkout -- .)",
       "Bash(git clean -f *)",
+      "Bash(git rebase)",
       "Bash(git rebase *)"
     ]
   },

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -10,7 +10,8 @@
       "Bash(git push * --force)",
       "Bash(git reset --hard *)",
       "Bash(git checkout -- .)",
-      "Bash(git clean -f *)"
+      "Bash(git clean -f *)",
+      "Bash(git rebase *)"
     ]
   },
   "hooks": {
@@ -52,6 +53,11 @@
             "type": "command",
             "command": "~/.claude/hooks/helm-version-required.sh",
             "statusMessage": "Checking helm version pinning"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/no-rebase.sh",
+            "statusMessage": "Checking for git rebase"
           }
         ]
       }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Check if the assistant just created or modified a pull request. If so, verify: (1) It was created as a DRAFT PR (--draft flag), (2) The assistant did NOT suggest merging or mark it ready, (3) The assistant's final message tells the user the PR URL and stops — it does NOT suggest next steps about merging. If any of these are violated, return {\"ok\": false, \"reason\": \"PR must be draft. Never suggest merging. Stop after providing PR URL.\"}. $ARGUMENTS",
+            "prompt": "Check ONLY the assistant's most recent response (the single message immediately above this check). If that specific response created or modified a pull request, verify: (1) It used the --draft flag, (2) It did NOT suggest merging or mark it ready, (3) It ends with the PR URL and nothing else — no trailing commentary, status updates, or next steps. If the most recent response did NOT create or modify a PR, return ok. Only evaluate the single most recent assistant message. $ARGUMENTS",
             "timeout": 15
           }
         ]


### PR DESCRIPTION
## Summary

Refs #71

- Add no-rebase.sh PreToolUse hook (Layer 3) blocking all forms of git rebase
- Add Bash(git rebase *) deny rule in permissions (Layer 2)
- Register hook in settings.json with status message

Uses the same shell-boundary-aware regex pattern as no-push-to-main.sh to avoid false positives on quoted strings.

Tested against: git rebase main, git rebase -i, --onto, --abort, --continue, chained (&&), sudo, bare git rebase, and verified passthrough for git merge and non-Bash tools.

## Test plan

- [x] Verify git rebase main is blocked by hook (deny output)
- [x] Verify git merge main passes through (no output)
- [x] Verify echo git rebase passes through (false positive check)
- [x] Verify git fetch && git rebase origin/main is blocked (chained command)
- [x] Verify make install-claude symlinks the new hook correctly
