### PR TITLE
fix(hooks): remove LLM-based Stop hook — false positive on every response 🐛

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -62,17 +62,6 @@
           }
         ]
       }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "Check ONLY the assistant's most recent response (the single message immediately above this check). If that specific response created or modified a pull request, verify: (1) It used the --draft flag, (2) It did NOT suggest merging or mark it ready, (3) It ends with the PR URL and nothing else — no trailing commentary, status updates, or next steps. If the most recent response did NOT create or modify a PR, return ok. Only evaluate the single most recent assistant message. $ARGUMENTS",
-            "timeout": 15
-          }
-        ]
-      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

- Remove the `Stop` prompt hook from `claude/settings.json`
- It was firing false positives on every assistant response

## Test plan

- [x] `make install-claude` re-symlinks updated settings
- [x] No stop hook errors on normal conversational responses
- [x] PR workflow rules still enforced via CLAUDE.md + deny rules + memory

Refs #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)
