### PR TITLE
docs(skills): cross-ref nix-modules-hardening from security and nix 🎓

### DIFF
--- a/claude/skills/nix/SKILL.md
+++ b/claude/skills/nix/SKILL.md
@@ -5,6 +5,8 @@ description: Nix flake hygiene, reproducible builds, OCI image patterns, devenv 
 
 # Nix Skill
 
+This skill covers flake-level concerns: building artefacts, packaging them for OCI, setting up devenv, layering task runners, Android SDK provisioning, and flake-evaluation security. Once you move from *producing* an artefact to *running it as a hardened systemd service on NixOS*, see the [`nix-modules-hardening` skill](../nix-modules-hardening/SKILL.md) for `services.<name>` module authoring, `DynamicUser` + `LoadCredential` patterns, and the systemd hardening matrix (`ProtectSystem`, `RestrictAddressFamilies`, `SystemCallFilter`, etc.).
+
 ## Flake Hygiene
 
 ### Input Updates

--- a/claude/skills/security/SKILL.md
+++ b/claude/skills/security/SKILL.md
@@ -43,6 +43,7 @@ description: Cross-cutting security guidance for authentication, authorisation, 
 - Never run `kubectl get secret -o yaml` — base64 is not encryption, and the output may be logged.
 - Terraform sensitive vars: use `TF_VAR_*` environment variables, never `-var` flags with inline values.
 - Git: never commit `.env`, `credentials.json`, private keys, or bearer tokens. Use `.gitignore` and pre-commit hooks.
+- NixOS services: ingest secrets via `LoadCredential=name:/path` on the systemd unit; the service reads from `$CREDENTIALS_DIRECTORY/name` and never touches the source path. Avoid `Environment=` / `EnvironmentFile=` for secrets, and avoid `export`-ing credentials into the process environment as the default pattern — `/proc/<pid>/environ` is visible to other processes with matching UID, and the value leaks into coredumps, child processes, and crash-reporter logs. See the [`nix-modules-hardening` skill](../nix-modules-hardening/SKILL.md) for the full wiring pattern with `DynamicUser` services.
 
 ## Input Validation
 
@@ -62,6 +63,7 @@ description: Cross-cutting security guidance for authentication, authorisation, 
 - Rust binaries: static linking via `x86_64-unknown-linux-musl` target or Nix `pkgsStatic`.
 - No shell in production containers where possible — reduces attack surface for container escape.
 - Read-only filesystem: set `readOnlyRootFilesystem: true` in Kubernetes security context.
+- NixOS systemd services are the non-container equivalent: use `DynamicUser = true;` (stateless services), `ProtectSystem = "strict"`, `NoNewPrivileges`, `CapabilityBoundingSet = [ "" ]`, narrow `RestrictAddressFamilies`, and `SystemCallFilter` with the standard deny groups. See the [`nix-modules-hardening` skill](../nix-modules-hardening/SKILL.md) for the full defense-in-depth matrix and JIT opt-outs for BEAM / V8 / LuaJIT / ONNX / JVM runtimes.
 
 ## Fail-Closed Design
 


### PR DESCRIPTION
## Summary

Follow-up to #83. The new `nix-modules-hardening` skill already links back to the `nix` skill at its top; this PR adds the reverse-direction cross-refs from `nix` and contextual forward-refs from `security` so readers landing in either skill get pointed at module-authoring / systemd-hardening guidance when they need it.

## Changes

- **`nix` skill**: new one-line scope paragraph at the top noting that module-authoring / systemd-hardening concerns live in `nix-modules-hardening`
- **`security` skill**, Secret Handling section: bullet about `LoadCredential` for NixOS services, calling out the env-var trap (`/proc/<pid>/environ`, coredumps, child inheritance) and pointing at the full wiring pattern
- **`security` skill**, Container Hardening section: bullet about NixOS systemd services as the non-container equivalent, naming the baseline hardening options and pointing at the full defense-in-depth matrix + JIT opt-outs

Total diff: 2 files, +4 lines.

## Test plan

- [ ] `make install-claude` symlink picks up the updated skills automatically (symlinks the `skills/` directory)
- [ ] Repo-relative links `../nix-modules-hardening/SKILL.md` resolve in both files
- [ ] No changes to `nix-modules-hardening` itself

Refs #85
