### PR TITLE
feat(skill): extend nix-modules-hardening with M2 patterns 🎓

### DIFF
--- a/claude/skills/nix-modules-hardening/SKILL.md
+++ b/claude/skills/nix-modules-hardening/SKILL.md
@@ -85,7 +85,7 @@ Every module accepting config SHOULD expose `settings` (or `extraArgs` for CLI-o
 
 ### Opt-in escape hatches for known-bad workarounds (`extra*` variants)
 
-Sometimes the upstream binary has a known bug that needs a workaround for ANY deployment to function. The naive shape is to bake the workaround into the wrapper as default behaviour, but that pattern silently bypasses the upstream fix forever once it ships — the workaround keeps firing because nobody remembers to remove it. The disciplined alternative is an **opt-in** escape hatch:
+Sometimes the upstream binary has a known bug that some deployments need a workaround for (a specific affected version range, a particular runtime configuration that surfaces it, etc.). The naive shape is to bake the workaround into the wrapper as default behaviour, but that pattern silently bypasses the upstream fix forever once it ships — the workaround keeps firing because nobody remembers to remove it. The disciplined alternative is an **opt-in** escape hatch:
 
 - Default to off (empty string, `null`, etc.).
 - The integration-test fixture sets it to the workaround SQL/script value and explains why inline.
@@ -121,7 +121,7 @@ extraPostMigrateFile = mkOption {
   # before assertions run. Pair with the same eval-time
   # `lib.hasPrefix "/nix/store/"` rejection + runtime `realpath -e`
   # check used for every other path-typed secret option in this skill
-  # (see "Two-layer off-store path enforcement" above).
+  # (see "Two-layer off-store path enforcement" below).
   type = types.nullOr (types.strMatching "^/");
   default = null;
   description = ''
@@ -312,7 +312,7 @@ Every path-typed secret option (`*File` / `*.path`) takes a path that MUST resol
 }
 ```
 
-The eval-time check catches Nix-path literals (`./secret` auto-copying to the store) and hand-written `/nix/store/...` paths, but **`environment.etc."<name>".text = …` slips through**: NixOS realises the bytes into a content-addressed store path and bind-mounts it at `/etc/<name>`. The consumer-visible path (`/etc/<name>`) is not literally under `/nix/store/`, so the eval-time assertion passes — but the bytes ARE in the world-readable store, defeating the secrets contract.
+The eval-time check catches Nix-path literals (`./secret` auto-copying to the store) and hand-written `/nix/store/...` paths, but **`environment.etc."<name>".text = …` slips through**: NixOS realises the bytes into a content-addressed store path and exposes it at `/etc/<name>` via a symlink into the store. The consumer-visible path (`/etc/<name>`) is not literally under `/nix/store/`, so the eval-time assertion passes — but the bytes ARE in the world-readable store, defeating the secrets contract.
 
 The fix is two layers:
 
@@ -814,10 +814,11 @@ let
   cfg = config.services.my-service;
 
   # `localhost` covers IPv4 + IPv6 loopback via /etc/hosts;
-  # `127.0.0.1` is the IPv4 literal. The host regex on databaseHost
-  # (^[a-zA-Z0-9.-]+$) forbids `:`, so IPv6 literals like `::1`
-  # cannot be configured against this option type and would be
-  # unreachable defensive code if added here.
+  # `127.0.0.1` is the IPv4 literal. If your `databaseHost` option
+  # type does not allow `:` (e.g. a host regex like
+  # `^[a-zA-Z0-9.-]+$`), IPv6 literals like `::1` cannot be
+  # configured against it and would be unreachable defensive code
+  # if added here.
   loopbackHosts = [ "localhost" "127.0.0.1" ];
   postgresLocal = lib.elem cfg.databaseHost loopbackHosts;
 in {
@@ -845,7 +846,7 @@ The predicate becomes the single source of truth for "is this dependency local".
 
 ### Operator `extraEnv` precedence — gate hardcoded fallbacks
 
-The module-wide convention is "operator wins on key collision" — `extraEnv` is the operator's escape hatch and any hardcoded value the wrapper sets should not silently clobber it. The naive shape is to `export VAR="..."` unconditionally in the start script, which loses to whatever systemd `Environment=` set first and clobbers it BEFORE the BEAM/Node.js/Go process inherits the env. Gate the hardcoded fallback on `[ -z "${VAR:-}" ]`:
+The module-wide convention is "operator wins on key collision" — `extraEnv` is the operator's escape hatch and any hardcoded value the wrapper sets should not silently clobber it. The naive shape is to `export VAR="..."` unconditionally in the start script, which inherits whatever systemd `Environment=` set first and then overwrites/clobbers that value BEFORE the BEAM/Node.js/Go process inherits the env. Gate the hardcoded fallback on `[ -z "${VAR:-}" ]`:
 
 ```nix
 # WRONG — operator's extraEnv.RELEASE_COOKIE is silently clobbered.

--- a/claude/skills/nix-modules-hardening/SKILL.md
+++ b/claude/skills/nix-modules-hardening/SKILL.md
@@ -83,6 +83,90 @@ settings = mkOption {
 
 Every module accepting config SHOULD expose `settings` (or `extraArgs` for CLI-only programs) as the escape hatch — operators must never have to fork the module to set a config value.
 
+### Opt-in escape hatches for known-bad workarounds (`extra*` variants)
+
+Sometimes the upstream binary has a known bug that needs a workaround for ANY deployment to function. The naive shape is to bake the workaround into the wrapper as default behaviour, but that pattern silently bypasses the upstream fix forever once it ships — the workaround keeps firing because nobody remembers to remove it. The disciplined alternative is an **opt-in** escape hatch:
+
+- Default to off (empty string, `null`, etc.).
+- The integration-test fixture sets it to the workaround SQL/script value and explains why inline.
+- Production deployments get clean default behaviour and only opt in when they need to.
+- The unit logs a stderr line every time the option fires, so the workaround leaves an audit trail in `journalctl`.
+- Mutually-exclusive store-vs-tmpfs variants (`extraPostMigrate` accepting a string baked into `pkgs.writeText`, `extraPostMigrateFile` accepting a path ingested via `LoadCredential=`) cover both non-secret and secret cases.
+
+```nix
+extraPostMigrate = mkOption {
+  type = types.lines;
+  default = "";
+  description = ''
+    SQL block run by `psql` after migrations and before the BEAM
+    supervisor starts. Empty by default — operators opt in
+    explicitly.
+
+    WARNING: rendered into `pkgs.writeText` → world-readable file
+    in `/nix/store/`. MUST NOT contain sensitive values; for SQL
+    that has to carry secrets, use `extraPostMigrateFile` instead.
+
+    WARNING: SQL run here can silently bypass data-fix migrations.
+    The wrapper logs `applying ... extraPostMigrate{,File} SQL` to
+    stderr every invocation so the bypass is visible in journalctl.
+    Document each statement's reason in the value, and revisit on
+    every upstream version bump.
+
+    Mutually exclusive with `extraPostMigrateFile`.
+  '';
+};
+
+extraPostMigrateFile = mkOption {
+  type = types.nullOr types.str;
+  default = null;
+  description = ''
+    Off-store alternative to `extraPostMigrate`. Absolute path to
+    a SQL file ingested via `LoadCredential=POST_MIGRATE_SQL=<path>`.
+    Two-layer off-store enforced (eval + runtime).
+  '';
+};
+```
+
+Wire-up:
+
+```nix
+${optionalString (cfg.extraPostMigrate != "" || cfg.extraPostMigrateFile != null) ''
+  echo "my-service: applying services.my-service.extraPostMigrate{,File} SQL" >&2
+  ${pkgs.postgresql}/bin/psql ... -f ${
+    if cfg.extraPostMigrate != "" then
+      "${pkgs.writeText "post-migrate.sql" cfg.extraPostMigrate}"
+    else
+      ''"$CREDENTIALS_DIRECTORY/POST_MIGRATE_SQL"''
+  }
+''}
+```
+
+Plus a `config.assertions` entry asserting only one of the two is set.
+
+### SQL identifier case-folding hazard
+
+Options whose values land in BOTH unquoted SQL (where PostgreSQL folds to lowercase) AND double-quoted SQL (case-sensitive) MUST be constrained to lowercase identifiers. The most common pattern: a wrapper that uses nixpkgs' `services.postgresql.ensureUsers` (which issues unquoted `CREATE ROLE <name>`) AND then issues `ALTER ROLE "${cfg.username}" WITH PASSWORD …` with double quotes. If the operator sets `username = "Blockscout"`:
+
+1. `ensureUsers` runs `CREATE ROLE Blockscout` (unquoted) → folded to `blockscout`.
+2. The wrapper runs `ALTER ROLE "Blockscout" WITH PASSWORD …` (quoted) → looks for the exact identifier `Blockscout`.
+3. PostgreSQL: `role "Blockscout" does not exist`. Unit fails at start.
+
+```nix
+# WRONG — allows uppercase, lets the case-folding hazard through.
+username = mkOption {
+  type = types.strMatching "^[a-zA-Z_][a-zA-Z0-9_]*$";
+  default = "myservice";
+};
+
+# RIGHT — lowercase-only, matches what `ensureUsers` actually creates.
+username = mkOption {
+  type = types.strMatching "^[a-z_][a-z0-9_]*$";
+  default = "myservice";
+};
+```
+
+Same constraint applies to `databaseName` and any other SQL identifier the wrapper double-quotes downstream. Add an inline comment on the option type explaining the case-folding rationale so future relaxations don't reintroduce the bug.
+
 ## Static vs Dynamic Users
 
 ### When to use `DynamicUser = true`
@@ -207,6 +291,114 @@ script = ''
 **Residual-risk note**: the critical boundary is between "secret inside systemd's credential tmpfs" (isolated to the service process) and "secret in process env / a writable file" (multiple leak paths — `/proc/<pid>/environ`, coredumps, child inheritance, accidental logging). Pattern 1 keeps the secret inside the tmpfs for its entire lifetime; Pattern 3 crosses the boundary and should be a conscious choice, not a default. If an app gives you a `--secret-file` or `--config` option, always prefer it over setting an env var.
 
 **Rule**: never put secrets in `Environment=`, `EnvironmentFile=`, or the Nix store. `LoadCredential=` + Pattern 1 is the correct ingestion path for `DynamicUser` services; Pattern 3 is the documented compromise when an app can't be changed.
+
+### Two-layer off-store path enforcement
+
+Every path-typed secret option (`*File` / `*.path`) takes a path that MUST resolve outside `/nix/store/`. A single layer of `lib.hasPrefix "/nix/store/" path` at evaluation time is necessary but **not sufficient**:
+
+```nix
+# WRONG — single layer, lets symlinks-into-store through.
+{
+  assertion =
+    lib.hasPrefix "/" cfg.secretFile
+    && !lib.hasPrefix "/nix/store/" cfg.secretFile;
+  message = "...";
+}
+```
+
+The eval-time check catches Nix-path literals (`./secret` auto-copying to the store) and hand-written `/nix/store/...` paths, but **`environment.etc."<name>".text = …` slips through**: NixOS realises the bytes into a content-addressed store path and bind-mounts it at `/etc/<name>`. The consumer-visible path (`/etc/<name>`) is not literally under `/nix/store/`, so the eval-time assertion passes — but the bytes ARE in the world-readable store, defeating the secrets contract.
+
+The fix is two layers:
+
+1. **Eval-time** `lib.hasPrefix` (fast, fails the build on the obvious mistakes).
+2. **Runtime** `realpath -e` `ExecStartPre=+<helper>` script (resolves symlinks, fails the unit if the resolved target is under `/nix/store/`).
+
+```nix
+# In `let`:
+checkSecretPathsScript = pkgs.writeShellScript "my-service-check-secret-paths" ''
+  set -u
+  fail=0
+
+  check() {
+    local name="$1" path="$2"
+    local resolved
+    if ! resolved=$(${pkgs.coreutils}/bin/realpath -e -- "$path" 2>/dev/null); then
+      echo "ERROR: services.my-service.''${name} = '$path' — does not exist, or has an unreadable parent directory at unit-start time." >&2
+      fail=1
+      return
+    fi
+    case "$resolved" in
+      /nix/store/*)
+        echo "ERROR: services.my-service.''${name} = '$path' resolves to '$resolved' which is under /nix/store/." >&2
+        echo "       Secrets in the world-readable Nix store defeat the module's secrets contract." >&2
+        echo "       Source from sops-nix / agenix into a tmpfs path (e.g. /run/secrets/...) instead." >&2
+        fail=1
+        ;;
+    esac
+  }
+
+  check secretFile ${lib.escapeShellArg cfg.secretFile}
+  ${lib.optionalString (cfg.cookieFile != null)
+    "check cookieFile ${lib.escapeShellArg cfg.cookieFile}"}
+
+  exit $fail
+'';
+
+# In serviceConfig:
+ExecStartPre = [ "+${checkSecretPathsScript}" ];
+```
+
+The leading `+` runs the helper as root regardless of `User=` / `DynamicUser=` — needed because operator-supplied secret paths under `/run/secrets/...` (sops-nix / agenix typical setup) are often locked down to mode 0700 root and the dynamic user can't `realpath -e` them. See "ExecStartPre privilege escalation" below for the full rationale.
+
+#### Third validation step: readability as the consuming user
+
+If the file will be read by something other than the unit's `User=` (a setup script invoked from the unit's main script that drops to a different user, a downstream `psql` heredoc that runs in postgres's `User=`), the runtime check must ALSO verify the consuming user can read the file. Otherwise a path that `realpath -e`s cleanly and is off-store can still fail downstream:
+
+```nix
+# In the check script, after the /nix/store/ check:
+if ! ${pkgs.util-linux}/bin/runuser -u postgres -- ${pkgs.coreutils}/bin/test -r "$resolved"; then
+  echo "ERROR: services.my-service.passwordFile = '$path' (resolved to '$resolved') is not readable as user 'postgres'." >&2
+  echo "       This file is consumed by a step running as User=postgres — it must own or have group-read on the file." >&2
+  echo "       Typical sops-nix shape: \`sops.secrets.<name>.owner = \"postgres\"\` with mode 0400 OR group-readable mode 0440." >&2
+  exit 1
+fi
+```
+
+Without this third step, a file mode 0400 root-owned passes the runtime check (root reads anything via the `+` prefix) but fails when later consumed by a non-root user — and **the failure is silent** if the consumer is a shell pipeline like `cat … | tr -d '\n'` (the `tr` exit status hides the `cat` failure). See the silent-empty-pipeline entry in Anti-Patterns.
+
+#### Assertion message wording
+
+Both layers' error messages should:
+
+- Name the **option** that's misconfigured (`services.<module>.<option>`).
+- Name the **resolved target path** at runtime, separately from the input path. The operator may not realise their `/etc/foo` resolved into the store; spelling out the resolved path is the bridge between symptom and cause.
+- Point at the canonical fix: sops-nix / agenix into a tmpfs path.
+
+### `ExecStartPre=+<path>` privilege escalation
+
+systemd allows prefixes on `ExecStart*` directives that change how the command is run. The `+` prefix runs the command as **root, ignoring `User=` / `DynamicUser=`**. Two situations where it's the right tool:
+
+1. **Runtime checks that need to traverse root-only directories.** `realpath -e` on `/run/secrets/blockscout/db_password` requires search access on `/run/secrets/blockscout/` — usually mode 0700 root via sops-nix. The unit's `DynamicUser` can't traverse that directory; root can.
+2. **One-shot setup tasks before the main exec.** Things like `install -m 0600 -T <staged> <runtime-path>` that need to write into a state directory the unit's user will own once it's running, but currently has root-managed permissions.
+
+The cost is well-bounded: `+`-prefixed steps run as root for that ExecStartPre only, then the main `ExecStart` drops back to the unit's configured user. The hardened sandbox (`ProtectSystem`, `RestrictAddressFamilies`, `SystemCallFilter`, etc.) STILL applies to the `+`-prefixed command — only the user identity changes. So you keep all of defense-in-depth and only relax the user-ID restriction for the specific step that needs root.
+
+```nix
+serviceConfig = {
+  DynamicUser = true;
+  # ...
+  ExecStartPre = [
+    # Root-elevated check — verifies operator-supplied secret paths
+    # before the main exec drops to DynamicUser.
+    "+${checkSecretPathsScript}"
+    # Non-root setup that runs as the eventual DynamicUser, no `+`.
+    "${pkgs.coreutils}/bin/install -d -m 0700 \${STATE_DIRECTORY}/cache"
+  ];
+  ExecStart = "${lib.getExe cfg.package}";
+};
+```
+
+Use the `+` prefix sparingly — every elevation is a small departure from the principle of least privilege. But **for runtime checks specifically, it's the correct tool**: the alternative is leaving the check unable to validate paths that genuinely need root traversal.
 
 ## Defense-in-Depth Hardening Matrix
 
@@ -599,6 +791,89 @@ systemd.services.blockscout-backend = {
 
 `network.target` is a systemd target meaning "networking is configured"; `network-online.target` is stronger (routes up). Use the weaker `network.target` unless the service needs outbound connections at startup.
 
+### Conditional ordering when an option can be local OR remote
+
+A common shape: an option whose value can point at either a local-loopback service (where the corresponding wrapper unit lives on this host) OR a remote host (where there is no local unit to order against). Hardcoded `requires=postgresql.service` on the consumer fails immediately on remote-host configs — the local `postgresql.service` doesn't exist, systemd reports "missing required unit", the consumer never starts.
+
+The pattern: a `loopbackHosts` predicate gates BOTH `after=`/`requires=` AND any local-vs-remote-different env-var defaults:
+
+```nix
+let
+  cfg = config.services.my-service;
+
+  # `localhost` covers IPv4 + IPv6 loopback via /etc/hosts;
+  # `127.0.0.1` is the IPv4 literal. The host regex on databaseHost
+  # (^[a-zA-Z0-9.-]+$) forbids `:`, so IPv6 literals like `::1`
+  # cannot be configured against this option type and would be
+  # unreachable defensive code if added here.
+  loopbackHosts = [ "localhost" "127.0.0.1" ];
+  postgresLocal = lib.elem cfg.databaseHost loopbackHosts;
+in {
+  systemd.services.my-service = {
+    after = [ "network-online.target" ]
+      ++ lib.optional postgresLocal "postgresql.service";
+    requires = lib.optional postgresLocal "postgresql.service";
+
+    environment = {
+      # Same predicate gates env-var defaults. ECTO_USE_SSL must
+      # be false against a plaintext loopback Postgres (the wrapper
+      # ships no certs); cloud-managed Postgres (RDS, Cloud SQL,
+      # Aurora) typically REQUIRES SSL, so non-loopback hosts get
+      # the safer default. Operators can always override via
+      # extraEnv.
+      ECTO_USE_SSL = if postgresLocal then "false" else "true";
+    };
+  };
+}
+```
+
+The predicate becomes the single source of truth for "is this dependency local". If the unit gains another flag whose default depends on the same question (timeouts, hostname-vs-IP forms, etc.), gate it on the same `postgresLocal` rather than re-deriving.
+
+**Edge case worth documenting on the option**: when the upstream binding option (e.g. `services.postgresql.settings.listen_addresses = "localhost"`) resolves the name and binds every returned address, leaving `databaseHost = "localhost"` is fine because both v4 + v6 loopback are reachable. When the upstream binds only the literal value (e.g. `services.redis.servers.<name>.bind = "127.0.0.1"`), the consumer's default should match the literal so `getaddrinfo("localhost")` returning `::1` first on dual-stack systems doesn't pick an unreachable address. Asymmetric defaults across two consumers reflect asymmetric upstream behaviour, not a bug.
+
+### Operator `extraEnv` precedence — gate hardcoded fallbacks
+
+The module-wide convention is "operator wins on key collision" — `extraEnv` is the operator's escape hatch and any hardcoded value the wrapper sets should not silently clobber it. The naive shape is to `export VAR="..."` unconditionally in the start script, which loses to whatever systemd `Environment=` set first and clobbers it BEFORE the BEAM/Node.js/Go process inherits the env. Gate the hardcoded fallback on `[ -z "${VAR:-}" ]`:
+
+```nix
+# WRONG — operator's extraEnv.RELEASE_COOKIE is silently clobbered.
+export RELEASE_COOKIE="$(openssl rand -hex 24)"
+exec ${cfg.package}/bin/server start
+
+# RIGHT — precedence chain: file > extraEnv > random fallback.
+${optionalString (cfg.cookieFile != null) ''
+  export RELEASE_COOKIE="$(cat "$CREDENTIALS_DIRECTORY/RELEASE_COOKIE")"
+''}
+${optionalString (cfg.cookieFile == null) ''
+  if [ -z "''${RELEASE_COOKIE:-}" ]; then
+    export RELEASE_COOKIE="$(${pkgs.openssl}/bin/openssl rand -hex 24)"
+  fi
+''}
+exec ${cfg.package}/bin/server start
+```
+
+Document the precedence chain in the option's docstring (`cookieFile` > `extraEnv.RELEASE_COOKIE` > random per-restart) so future reviewers don't reintroduce the unconditional export. Note the `''$` escape on `''${RELEASE_COOKIE:-}` — see "`''$` escape inside indented strings" below.
+
+### `''$` escape inside indented strings
+
+Indented `''…''` Nix strings parse `${var}` as antiquotation **everywhere inside the string**, including comment lines and shell `${VAR}` parameter expansions. To pass a literal `${...}` through to the rendered script body, escape with `''$`:
+
+```nix
+# WRONG — `${RELEASE_COOKIE:-}` parsed as Nix antiquotation; eval fails.
+startScript = pkgs.writeShellScript "start" ''
+  # Use `${RELEASE_COOKIE:-}` to test if it's set
+  if [ -z "${RELEASE_COOKIE:-}" ]; then ...; fi
+'';
+
+# RIGHT — `''$` escapes the dollar sign so Nix leaves `${...}` alone.
+startScript = pkgs.writeShellScript "start" ''
+  # Use `''${RELEASE_COOKIE:-}` to test if it's set
+  if [ -z "''${RELEASE_COOKIE:-}" ]; then ...; fi
+'';
+```
+
+The escape applies to comments too — a Nix-side comment inside an indented string is part of the string, not a Nix-language comment. If `${...}` appears in your prose, escape it with `''$` even if you don't intend it as an interpolation.
+
 ## Anti-Patterns
 
 - Using a static UID without a stateful-data justification — if you can't name a specific reason tied to on-disk persistence (e.g. PostgreSQL data directory ownership), use `DynamicUser = true`
@@ -617,6 +892,9 @@ systemd.services.blockscout-backend = {
 - `SystemCallFilter` that blanket-allows `@system-service` without `~@privileged ~@resources` — defeats most of the hardening; always pair the baseline group with explicit subtractions
 - Writing a new module that doesn't expose `extraArgs` / `settings` / `extraConfig` — operators will eventually need to pass a flag; if there's no escape hatch they must fork the module
 - Defining a service with `User =` and `Group =` but also `DynamicUser = true` — contradictory; systemd uses the dynamic allocation and ignores the static names, but the declaration is confusing and review-hostile
+- **Silent-empty-pipeline on secret reads** — `cat <file> | tr -d '\n'` (or any pipe with `cat` first) inherits the LAST stage's exit status, not `cat`'s. If `cat` fails (Permission denied, file missing) the trailing `tr` succeeds on empty input and the pipeline returns 0 with empty stdout. Catastrophic when the captured value drives `ALTER ROLE … WITH PASSWORD '<empty>'` (silently clears the password) or any other "pass empty string when secret is missing" downstream. Fix: preflight `cat <file> > /dev/null` (gets `cat`'s real exit status), `[ -s <file> ]` (rejects empty files), AND the `runuser -u <user> -- test -r` runtime check on the secrets path so unreadability fails the unit at unit-start before any consumer can see empty output. Defense-in-depth: ship all three, so losing one doesn't reintroduce the silent-clearing path.
+- **Mixed-case PostgreSQL identifiers** — letting `databaseName` / `username` accept uppercase (`^[a-zA-Z_]...`) breaks `ensureUsers` + double-quoted `ALTER ROLE` interaction. nixpkgs creates the role with unquoted CREATE (folds to lowercase); the wrapper later targets the exact-case identifier with double quotes and gets `role "Capitalized" does not exist`. Constrain to `^[a-z_][a-z0-9_]*$` — see "SQL identifier case-folding hazard" above.
+- **Operator `extraEnv` clobbered by hardcoded wrapper export** — module-wide rule is "operator wins on `extraEnv` key collision". Unconditional `export VAR="..."` in the start script clobbers whatever systemd `Environment=` set first. Gate the hardcoded fallback on `[ -z "''${VAR:-}" ]` (precedence chain: cookieFile/secretFile > extraEnv > random/computed fallback) and document the chain in the option's docstring.
 
 ## Quick-Reference Baseline Template
 

--- a/claude/skills/nix-modules-hardening/SKILL.md
+++ b/claude/skills/nix-modules-hardening/SKILL.md
@@ -117,12 +117,18 @@ extraPostMigrate = mkOption {
 };
 
 extraPostMigrateFile = mkOption {
-  type = types.nullOr types.str;
+  # `types.strMatching "^/"` rejects relative paths at the type level,
+  # before assertions run. Pair with the same eval-time
+  # `lib.hasPrefix "/nix/store/"` rejection + runtime `realpath -e`
+  # check used for every other path-typed secret option in this skill
+  # (see "Two-layer off-store path enforcement" above).
+  type = types.nullOr (types.strMatching "^/");
   default = null;
   description = ''
     Off-store alternative to `extraPostMigrate`. Absolute path to
-    a SQL file ingested via `LoadCredential=POST_MIGRATE_SQL=<path>`.
-    Two-layer off-store enforced (eval + runtime).
+    a SQL file ingested via `LoadCredential=POST_MIGRATE_SQL:<path>`
+    (note the `NAME:PATH` colon — NOT `NAME=PATH`; systemd rejects
+    the `=` form). Two-layer off-store enforced (eval + runtime).
   '';
 };
 ```

--- a/claude/skills/nix-modules-hardening/SKILL.md
+++ b/claude/skills/nix-modules-hardening/SKILL.md
@@ -130,7 +130,7 @@ extraPostMigrateFile = mkOption {
 Wire-up:
 
 ```nix
-${optionalString (cfg.extraPostMigrate != "" || cfg.extraPostMigrateFile != null) ''
+${lib.optionalString (cfg.extraPostMigrate != "" || cfg.extraPostMigrateFile != null) ''
   echo "my-service: applying services.my-service.extraPostMigrate{,File} SQL" >&2
   ${pkgs.postgresql}/bin/psql ... -f ${
     if cfg.extraPostMigrate != "" then
@@ -381,7 +381,13 @@ systemd allows prefixes on `ExecStart*` directives that change how the command i
 1. **Runtime checks that need to traverse root-only directories.** `realpath -e` on `/run/secrets/blockscout/db_password` requires search access on `/run/secrets/blockscout/` — usually mode 0700 root via sops-nix. The unit's `DynamicUser` can't traverse that directory; root can.
 2. **One-shot setup tasks before the main exec.** Things like `install -m 0600 -T <staged> <runtime-path>` that need to write into a state directory the unit's user will own once it's running, but currently has root-managed permissions.
 
-The cost is well-bounded: `+`-prefixed steps run as root for that ExecStartPre only, then the main `ExecStart` drops back to the unit's configured user. The hardened sandbox (`ProtectSystem`, `RestrictAddressFamilies`, `SystemCallFilter`, etc.) STILL applies to the `+`-prefixed command — only the user identity changes. So you keep all of defense-in-depth and only relax the user-ID restriction for the specific step that needs root.
+The cost is **not** just a temporary UID change. Per `systemd.exec(5)`, the `+` prefix runs the command with **full privileges** for that exec line: `ProtectSystem`, `RestrictAddressFamilies`, `SystemCallFilter`, capability bounds, namespace isolation, and most other sandboxing restrictions are bypassed. The main `ExecStart` still drops back to the unit's configured user, but the `+` step itself runs essentially uncontained — treat it as a narrowly-scoped privileged escape hatch.
+
+Practical guidance:
+
+- **Prefer designs that avoid `+` entirely.** If a runtime check can be expressed as a `config.assertions` entry at evaluation time, do that instead.
+- **If the intent is "run as root for startup credential / permission handling" without losing the sandbox**, consider `PermissionsStartOnly=true` (which keeps `ProtectSystem`, `SystemCallFilter`, etc. on while only granting root to `ExecStartPre`/`ExecStartPost` lines). It's narrower than `+` and worth reaching for first.
+- **If `+` is unavoidable** (e.g. the helper genuinely needs to traverse a `/run/secrets/` dir locked to mode 0700 root), keep it to a tiny purpose-built helper that does the minimum necessary work and exits. The smaller the privileged window, the less your security posture depends on the `+` step staying simple.
 
 ```nix
 serviceConfig = {
@@ -841,10 +847,10 @@ export RELEASE_COOKIE="$(openssl rand -hex 24)"
 exec ${cfg.package}/bin/server start
 
 # RIGHT — precedence chain: file > extraEnv > random fallback.
-${optionalString (cfg.cookieFile != null) ''
+${lib.optionalString (cfg.cookieFile != null) ''
   export RELEASE_COOKIE="$(cat "$CREDENTIALS_DIRECTORY/RELEASE_COOKIE")"
 ''}
-${optionalString (cfg.cookieFile == null) ''
+${lib.optionalString (cfg.cookieFile == null) ''
   if [ -z "''${RELEASE_COOKIE:-}" ]; then
     export RELEASE_COOKIE="$(${pkgs.openssl}/bin/openssl rand -hex 24)"
   fi


### PR DESCRIPTION
## Summary

Extends `nix-modules-hardening` (PR #84, 682 lines) with nine patterns surfaced during the `klazomenai/autonity-blockscout-nixos` M2 service-module sweep — six modules + hardening matrix spike + full-stack VM integration test, ~16 Copilot review rounds across 4 PRs (#20, #26, #27 + the staticNodes follow-up #6 in the same repo). The skill grew from 682 → 960 lines (under the 1000-line target in #89). All additions are concentrated; no existing material rewritten.

## What's new (by section)

**Under `LoadCredential`** — secrets-handling has the heaviest M2 payload:
- **Two-layer off-store secrets contract** — eval-time `lib.hasPrefix` is necessary but not sufficient (symlinks-into-store via `environment.etc` slip through). Runtime `realpath -e` `ExecStartPre=+<helper>` script closes the loophole. Includes the canonical helper-script shape.
- **Third validation step**: `runuser -u <user> -- test -r` for paths consumed by a non-unit User=. Caught a real bug during PR #27 review.
- **`ExecStartPre=+<path>` privilege escalation** — when the `+` prefix is the right tool, decision criteria, and the principle-of-least-privilege framing.

**Under Module Option Conventions**:
- **Opt-in escape hatches for known-bad workarounds** — when upstream bugs need workarounds, ship as opt-in not default. The `extraPostMigrate` / `extraPostMigrateFile` two-variant pattern (store-resident non-secret vs LoadCredential off-store secret), mutually-exclusive, audit-log line.
- **SQL identifier case-folding hazard** — `databaseName` / `username` MUST be `^[a-z_][a-z0-9_]*$` to avoid the unquoted-CREATE-vs-double-quoted-ALTER mismatch.

**Under Unit Ordering**:
- **Conditional ordering when an option can be local OR remote** — the `loopbackHosts` predicate, gating both `after=`/`requires=` AND env-var defaults (e.g. `ECTO_USE_SSL` false on loopback / true on remote).
- **Operator `extraEnv` precedence** — gate hardcoded fallbacks on `[ -z "${VAR:-}" ]` so operator overrides win on key collision.
- **`''$` escape inside indented strings** — Nix antiquotation parses `${...}` everywhere in `''…''` strings including comments. Escape with `''$`.

**In Anti-Patterns**:
- Silent-empty-pipeline on secret reads (the `cat | tr` exit-status-from-trailing-stage trap).
- Mixed-case PostgreSQL identifiers.
- Operator `extraEnv` clobbered by hardcoded wrapper export.

## Acceptance criteria (from #89)

- [x] Two-layer off-store secrets contract documented with helper-script shape.
- [x] `ExecStartPre=+<path>` privilege escalation documented with worked example and decision criteria.
- [x] `runuser -u <user> -- test -r` documented as the third validation step.
- [x] Silent-empty-pipeline anti-pattern added.
- [x] `loopbackHosts` predicate documented with unit-ordering + env-var-default uses.
- [x] `extraPostMigrate{,File}` opt-in escape-hatch pattern documented.
- [x] PostgreSQL identifier case-folding hazard documented.
- [x] Operator-`extraEnv`-clobbered anti-pattern added with precedence-chain fix.
- [x] `''$` escape inside indented strings documented.
- [x] Skill stays under 1000 lines (960). No existing material rewritten.

## Test plan

- [x] `make install-claude` continues to symlink the skill into `~/.claude/skills/`.
- [x] All new code blocks compile-check by inspection (no Nix evaluator on dotfiles; the live-fire test is the consuming `klazomenai/autonity-blockscout-nixos` repo's `nix flake check`, which exercises every pattern in this PR's additions).
- [x] Skill remains readable end-to-end — additions slot into existing sections at logical insertion points rather than tacked on at the end.

## Out of scope (filed as future skill PRs)

- **`testing` skill**: `wait_until_succeeds` discipline, behavioural-side-effect assertion pattern, nginx `--resolve` SNI alignment, hardening-matrix scope-narrowing, `/run/test-secrets/` fixture pattern with multi-consumer ownership.
- **`blockscout` skill**: Postgrex URL parser limitations, Redix `unix://` rejection, `Explorer.ReleaseTasks.migrate([])` rename, `ECTO_USE_SSL`, `/api/health/{liveness,readiness}` vs `/api/v2/health` matrix, the `ReindexDuplicatedInternalTransactions` upstream regression.
- **`autonity` skill**: `static-nodes.json` Geth-family file convention, monitor.go empty-CPU-slice panic, `--nodiscover --maxpeers=0` hermetic test mode.
- **`nix` skill**: `lib.escapeShellArg` over manual `'…'`, `pkgs.writeText`-stage + `install -m 0600 -T` for non-secret operator config, drv-hash-stability as drift proof. The `''$` escape lives in `nix-modules-hardening` here because the example is a service-module shell wrapper, but a cross-ref note from the `nix` skill would be sensible.

Each tracked separately so each skill stays focused on its own domain.

Refs #89
