### PR TITLE
docs(skill): split gh pr create vs gh api flag patterns in github skill 🎓

### DIFF
--- a/claude/skills/github/SKILL.md
+++ b/claude/skills/github/SKILL.md
@@ -40,7 +40,7 @@ description: Git and GitHub workflow guidance, including commits, branches, PRs,
   ## Test plan
   - [ ] Bulleted checklist of testing TODOs
   ```
-- Use temp files for PR bodies to avoid hook false positives: write body to file, use `-F "body=@file"`
+- Use temp files for PR bodies to avoid hook false positives: write body to file, then `gh pr create --body-file path/to/file --draft ...`. (Note: `--body-file <path>` is the `gh pr create` flag; the `-F body=@file` form-field syntax is for `gh api` calls only — see PR Review Replies below.)
 
 ## Issue Conventions
 


### PR DESCRIPTION
## Summary

- Splits the conflated `gh pr create` / `gh api` flag guidance on line 43 of `claude/skills/github/SKILL.md`. The line lived in the **Pull Requests** section (so context = `gh pr create`) but used `-F "body=@file"`, which is `gh api` form-field syntax.
- Replaced with `gh pr create --body-file path/to/file --draft ...` plus a parenthetical disambiguating the two flag families.
- Lines 67 and 81 in the PR Review Replies / Copilot Review Workflow sections are correctly scoped to `gh api` and remain unchanged.

## Test plan

- [x] `grep -n 'body=@\|body-file' claude/skills/github/SKILL.md` confirms only line 43 changed; lines 67/81 unchanged
- [ ] Reviewer to spot-check the rewrite reads cleanly and that the disambiguating parenthetical is helpful, not noisy

Refs #93
