### PR TITLE
docs(skill): add ci to branch type allowlist in github skill 🎓

### DIFF
--- a/claude/skills/github/SKILL.md
+++ b/claude/skills/github/SKILL.md
@@ -20,7 +20,7 @@ description: Git and GitHub workflow guidance, including commits, branches, PRs,
 - NEVER push to "main" or default branch — NO EXCEPTIONS
 - NEVER create "master" branch
 - Naming: `<type>/<issue>-<description>` e.g. `feat/595-jaeger-tracing`, `fix/784-terraform-exit-code`
-- Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `security`, `spike`
+- Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `ci`, `security`, `spike`
 - Base branch: main | Merge style: squash merge | Delete branch after merge
 - No emojis in branch names
 


### PR DESCRIPTION
## Summary

- Adds `ci` to the branch-type allowlist in `claude/skills/github/SKILL.md`. The commit-type list (line 11) already includes `ci`; this closes the symmetric gap on the branch-type list.
- Caught when the embedded copy in `klazomenai/bridge#144` triggered a Copilot review noting an inconsistency between the skill's branch allowlist and bridge's CONTRIBUTING.md. Bridge's CONTRIBUTING was updated to include `spike` (its own gap, the user's global standing rule); this PR closes the upstream-side gap on `ci`.
- One-line change. No other section touched.

## Test plan

- [x] `grep -n 'Types:' claude/skills/github/SKILL.md` shows commit list line 11 has `ci`, branch list line 23 now has `ci` too
- [ ] Reviewer to spot-check the placement (kept near `docs` since both relate to non-source-code workstreams) reads cleanly

Refs #95