### PR TITLE
refactor(skill): split github skill into universal + operator + orchestrator slices 🎓

### DIFF
--- a/claude/skills/github/SKILL.md
+++ b/claude/skills/github/SKILL.md
@@ -5,13 +5,20 @@ description: Git and GitHub workflow guidance, including commits, branches, PRs,
 
 # Git + GitHub Skill
 
+This skill encodes the standing rules for git history, GitHub issues, pull
+requests, and review threads. The body below is the **universal core** —
+applies wherever this skill is loaded, including by autonomous agents that
+vendor or link this file.
+
+For human-Claude-Code-only addenda (co-author handling on private repos,
+hook false-positive workarounds, public-repo sanitisation), see [operator.md](operator.md).
+
 ## Commit Conventions
 
 - Conventional commits format: `<type>(scope): description`
 - Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `ci`, `perf`, `security`
 - Signed commits required: always use `--gpg-sign`
 - Use `Refs #N` in commit body — NEVER `Closes #N`, `Fixes #N`, or `Resolves #N` (closing is a merge-time decision)
-- NO Claude co-author line on private repos — check repo visibility with `gh repo view --json isPrivate -q '.isPrivate'` before committing
 - NEVER amend commits or force-push — stack separate signed commits, squash on merge
 - Commit emoji prefixes (in commit message, not branch): ✨ feat | 🐛 fix | 📝 docs | ♻️ refactor | 🧪 test | ⚙️ chore | 🔐 security | 🏗️ ci | ⚡ perf
 
@@ -20,7 +27,7 @@ description: Git and GitHub workflow guidance, including commits, branches, PRs,
 - NEVER push to "main" or default branch — NO EXCEPTIONS
 - NEVER create "master" branch
 - Naming: `<type>/<issue>-<description>` e.g. `feat/595-jaeger-tracing`, `fix/784-terraform-exit-code`
-- Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `security`, `spike`
+- Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `ci`, `security`, `spike`
 - Base branch: main | Merge style: squash merge | Delete branch after merge
 - No emojis in branch names
 
@@ -40,7 +47,7 @@ description: Git and GitHub workflow guidance, including commits, branches, PRs,
   ## Test plan
   - [ ] Bulleted checklist of testing TODOs
   ```
-- Use temp files for PR bodies to avoid hook false positives: write body to file, then `gh pr create --body-file path/to/file --draft ...`. (Note: `--body-file <path>` is the `gh pr create` flag; the `-F body=@file` form-field syntax is for `gh api` calls only — see PR Review Replies below.)
+- Write PR bodies to temp files for safe escaping of complex content: `gh pr create --body-file path/to/file --draft ...`. (`--body-file <path>` is the `gh pr create` flag; the `-F body=@file` form-field syntax is for `gh api` calls only — see PR Review Replies below.)
 
 ## Issue Conventions
 
@@ -77,18 +84,9 @@ Rules:
 
 When replying to PR review comments:
 
-- Write reply body to a temp file first to avoid hook false positives on `gh api` body content
+- Write reply body to a temp file for safe escaping of complex content
 - Pattern: `tmpfile=$(mktemp) && cat <<'EOF' > "$tmpfile" ... EOF` then `gh api ... -F "body=@$tmpfile" -F in_reply_to=<id> && rm -f "$tmpfile"`
 - Always reply inline to the specific comment thread, not as a standalone comment
-
-## Public Repo Security
-
-CRITICAL — applies to ALL public-facing text in public repositories:
-
-- NEVER reference private org names, private repo names, or internal infrastructure
-- Sanitization applies to EVERYTHING: PR titles, PR bodies, commit messages, branch names — not just file contents
-- Before creating a PR on a public repo: review title and body for any private/internal references
-- `gh repo create --push` pushes straight to main — NEVER use `--push` flag
 
 ## File Hygiene
 
@@ -103,7 +101,6 @@ CRITICAL — applies to ALL public-facing text in public repositories:
 - Pushing directly to main or default branch
 - Creating "master" branches
 - Using `Closes #N`, `Fixes #N`, or `Resolves #N` in commit messages (use `Refs #N`)
-- Adding Claude co-author to private repo commits
 - Using `gh pr merge` or `gh pr ready` (merging is a human decision)
 - Creating non-draft PRs
 - Committing secrets or credentials

--- a/claude/skills/github/SKILL.md
+++ b/claude/skills/github/SKILL.md
@@ -11,7 +11,7 @@ applies wherever this skill is loaded, including by autonomous agents that
 vendor or link this file.
 
 For human-Claude-Code-only addenda (co-author handling on private repos,
-hook false-positive workarounds, public-repo sanitisation), see [operator.md](operator.md).
+hook false-positive workarounds), see [operator.md](operator.md).
 
 ## Commit Conventions
 
@@ -87,6 +87,44 @@ When replying to PR review comments:
 - Write reply body to a temp file for safe escaping of complex content
 - Pattern: `tmpfile=$(mktemp) && cat <<'EOF' > "$tmpfile" ... EOF` then `gh api ... -F "body=@$tmpfile" -F in_reply_to=<id> && rm -f "$tmpfile"`
 - Always reply inline to the specific comment thread, not as a standalone comment
+
+## Public Repo Security
+
+CRITICAL — applies to ALL public-facing text in public repositories,
+regardless of who or what is generating that text:
+
+- NEVER reference private org names, private repo names, or internal
+  infrastructure
+- Sanitisation applies to EVERYTHING: PR titles, PR bodies, commit messages,
+  branch names, issue titles, issue bodies, review-comment replies — not
+  just file contents
+- Before creating or editing a public-repo artefact: review title and body
+  for any private/internal references, regardless of where the source text
+  came from (operator instruction, tool output, prior conversation context)
+- `gh repo create --push` pushes straight to main — NEVER use `--push` flag
+
+The risk is the same whether the source is a human's local environment
+(private hostnames, customer references, internal service names) or an
+autonomous agent's tool output (e.g. a `kubectl` result mentioning a
+private internal service that gets transcribed into an issue body).
+Generated text bound for public surfaces gets the same scrutiny as
+hand-typed text.
+
+## Sensitive Values in Command Arguments
+
+CRITICAL — applies to all command invocations, whether by a human at a
+shell or by an autonomous agent invoking subprocesses:
+
+- NEVER inline sensitive values (emails, keys, passwords, tokens) in
+  command arguments — they leak into shell history, process tables, audit
+  logs, and conversation logs
+- Use `export VAR=value` as a separate step before invoking the command,
+  or pass via files / env vars / stdin instead of argv
+- Applies to all CLIs: `gh`, `terraform`, `gcloud`, `kubectl`, `vault`,
+  `aut`, etc.
+- Audit logs are persistent — agents that log full command lines for
+  audit purposes are a particular leak risk; redact at log-time, not
+  display-time
 
 ## File Hygiene
 

--- a/claude/skills/github/SKILL.md
+++ b/claude/skills/github/SKILL.md
@@ -98,9 +98,11 @@ regardless of who or what is generating that text:
 - Sanitisation applies to EVERYTHING: PR titles, PR bodies, commit messages,
   branch names, issue titles, issue bodies, review-comment replies — not
   just file contents
-- Before creating or editing a public-repo artefact: review title and body
-  for any private/internal references, regardless of where the source text
-  came from (operator instruction, tool output, prior conversation context)
+- Before creating or editing a public-repo artefact: review the artefact in
+  full — every surface listed above (PR title, PR body, commit message,
+  branch name, issue title, issue body, review-comment reply) for any
+  private/internal references, regardless of where the source text came
+  from (operator instruction, tool output, prior conversation context)
 - `gh repo create --push` pushes straight to main — NEVER use `--push` flag
 
 The risk is the same whether the source is a human's local environment

--- a/claude/skills/github/operator.md
+++ b/claude/skills/github/operator.md
@@ -1,0 +1,74 @@
+# Git + GitHub Skill — Operator Addendum
+
+This file contains rules that only apply when this skill is consumed by a
+human at a Claude Code CLI (the "operator"). Autonomous agents that vendor
+or link this skill should ignore this file — they have their own constraints
+encoded in `orchestrator.md`.
+
+The universal workflow rules live in [SKILL.md](SKILL.md) and apply to both
+audiences.
+
+## Co-author Handling
+
+- NO Claude co-author line on private repos. Public-repo commits may include
+  it; private-repo commits must not.
+- Check repo visibility with `gh repo view --json isPrivate -q '.isPrivate'`
+  before committing if unsure.
+- The `no-coauthor-private.sh` PreToolUse hook fails closed on `private` and
+  on `unknown` visibility — if the hook blocks a commit, verify visibility
+  rather than bypassing.
+
+## Hook False-Positive Workarounds
+
+Claude Code's guardrail hooks pattern-match against full command strings,
+including argument values. Some legitimate `gh api` invocations (review-thread
+replies with rich-text bodies, PR creation with sample shell snippets in the
+body) trigger false positives on the body content.
+
+Workaround pattern:
+
+- Write the body to a temp file (`tmpfile=$(mktemp)` + heredoc)
+- Pass `-F "body=@$tmpfile"` to `gh api` (or `--body-file $tmpfile` to
+  `gh pr create`) so the body content never appears in the command string
+  the hook inspects
+- Clean up the temp file after the call
+
+This is the same temp-file pattern documented in the universal PR Review
+Replies section of `SKILL.md`, but the *reason* (hook false positives) is
+operator-specific. Autonomous agents have different (or no) hook layers and
+use the temp-file pattern for shell-escaping reasons instead.
+
+## Public Repo Security
+
+CRITICAL — applies to ALL public-facing text in public repositories:
+
+- NEVER reference private org names, private repo names, or internal
+  infrastructure
+- Sanitization applies to EVERYTHING: PR titles, PR bodies, commit messages,
+  branch names — not just file contents
+- Before creating a PR on a public repo: review title and body for any
+  private/internal references
+- `gh repo create --push` pushes straight to main — NEVER use `--push` flag
+
+These rules exist because the operator's local environment may contain
+private context (org names, internal hostnames, customer references) that
+must not leak into public-facing text. Autonomous agents have controlled
+inputs and a separate redaction layer — see `orchestrator.md` for the
+agent-side equivalents.
+
+## Sensitive Values in Command Arguments
+
+- NEVER inline sensitive values (emails, keys, passwords) in command
+  arguments — they leak into shell history, process tables, and conversation
+  logs.
+- Use `export VAR=value` as a separate step before invoking the command, or
+  prompt the operator to set the env var themselves.
+- Applies to all CLIs: `gh`, `terraform`, `gcloud`, `kubectl`, etc.
+
+## Anti-Patterns (operator-only)
+
+- Adding Claude co-author to private-repo commits
+- Bypassing the `no-coauthor-private.sh` hook on visibility=unknown
+- Inlining sensitive values in command arguments
+- Pushing private content (private org / repo / hostname references) into
+  public PR titles, bodies, or commit messages

--- a/claude/skills/github/operator.md
+++ b/claude/skills/github/operator.md
@@ -38,37 +38,24 @@ Replies section of `SKILL.md`, but the *reason* (hook false positives) is
 operator-specific. Autonomous agents have different (or no) hook layers and
 use the temp-file pattern for shell-escaping reasons instead.
 
-## Public Repo Security
-
-CRITICAL — applies to ALL public-facing text in public repositories:
-
-- NEVER reference private org names, private repo names, or internal
-  infrastructure
-- Sanitization applies to EVERYTHING: PR titles, PR bodies, commit messages,
-  branch names — not just file contents
-- Before creating a PR on a public repo: review title and body for any
-  private/internal references
-- `gh repo create --push` pushes straight to main — NEVER use `--push` flag
-
-These rules exist because the operator's local environment may contain
-private context (org names, internal hostnames, customer references) that
-must not leak into public-facing text. Autonomous agents have controlled
-inputs and a separate redaction layer — see `orchestrator.md` for the
-agent-side equivalents.
-
-## Sensitive Values in Command Arguments
-
-- NEVER inline sensitive values (emails, keys, passwords) in command
-  arguments — they leak into shell history, process tables, and conversation
-  logs.
-- Use `export VAR=value` as a separate step before invoking the command, or
-  prompt the operator to set the env var themselves.
-- Applies to all CLIs: `gh`, `terraform`, `gcloud`, `kubectl`, etc.
-
 ## Anti-Patterns (operator-only)
 
 - Adding Claude co-author to private-repo commits
 - Bypassing the `no-coauthor-private.sh` hook on visibility=unknown
-- Inlining sensitive values in command arguments
-- Pushing private content (private org / repo / hostname references) into
-  public PR titles, bodies, or commit messages
+
+## Universal Rules That Used To Live Here
+
+The following rules previously lived in this file but were promoted to the
+universal `SKILL.md` after a Copilot review on dotfiles PR #98 noted that
+they apply equally to autonomous agents:
+
+- **Public Repo Security** — sanitisation of public-repo artefacts now
+  lives in `SKILL.md`. Generated text from any source (operator, tool
+  output, prior conversation) gets the same scrutiny.
+- **Sensitive Values in Command Arguments** — secret-handling in argv now
+  lives in `SKILL.md`. Audit-log leakage applies to agents as much as
+  shell history applies to humans.
+
+If you find yourself wanting to put a "this applies to humans only" rule
+in this file, sense-check whether an autonomous agent could trigger the
+same failure mode. If yes, the rule belongs in `SKILL.md`.

--- a/claude/skills/github/orchestrator.md
+++ b/claude/skills/github/orchestrator.md
@@ -1,0 +1,97 @@
+# Git + GitHub Skill — Orchestrator Addendum
+
+This file contains rules that only apply when this skill is consumed by an
+autonomous agent — a Claude persona embedded in a long-running orchestrator
+(e.g. an Anthropic API tool-use loop) that operates on GitHub via `gh` or
+the GitHub REST/GraphQL APIs.
+
+This file is **intentionally not referenced from `SKILL.md`** — Claude Code
+will not auto-load it for human users. The orchestrator is expected to fetch
+this file by path at boot and concatenate it onto the persona's system
+prompt alongside the universal `SKILL.md` body.
+
+The universal workflow rules in `SKILL.md` apply equally to both audiences.
+The rules below are layered on top.
+
+## Repo Allowlist Enforcement
+
+Every write operation (issue create, edit, comment, PR create, PR comment,
+review reply, push) must verify the target repository is in the
+orchestrator's allowlist before invoking the underlying tool.
+
+- Allowlist is fail-closed: empty list = refuse all writes.
+- Refusal must be visible to the operator with a clear explanation —
+  which repo, why refused.
+- Read-only operations (issue view, PR view, etc.) may have a wider or
+  empty allowlist depending on the orchestrator's configuration — but
+  writes are always gated.
+
+## Token & Secret Redaction
+
+- Tool output returned to the model must be sanitised for tokens, secrets,
+  and other sensitive values before the model sees it.
+- Use the orchestrator's shared redaction layer (e.g. a project-level
+  redaction package) — do not write per-tool ad-hoc filters.
+- Command lines logged for audit purposes must be token-redacted at log
+  time, not at display time.
+
+## Mutation Gating — Explicit Confirmation
+
+State-change mutations require explicit confirmation in the operator's
+most recent message:
+
+- Closing or reopening an issue
+- Marking a PR ready for review (already universally forbidden by
+  `SKILL.md`, but reinforced here)
+- Pushing code, even to a feature branch
+- Resolving a review thread
+- Editing or deleting issue / PR / comment content
+
+Rules:
+
+- Don't infer consent from earlier conversation.
+- Ambiguity = ask, don't act.
+- A separate `confirm` boolean (extracted from the operator's words, not
+  auto-filled) is the preferred shape for tool input schemas where
+  applicable.
+
+## Copilot Review Threads
+
+The universal Copilot Review Workflow in `SKILL.md` applies, with an
+additional gate:
+
+- NEVER autonomously resolve Copilot review threads. Always reply with a
+  fix-commit reference; the operator resolves.
+- "Apply all suggestions" is not a valid action without explicit operator
+  consent on each comment.
+
+## PR Lifecycle Gates
+
+- Never call `gh pr merge`. CI green is not consent.
+- Never call `gh pr ready`. The operator decides when a draft becomes ready.
+- Never push code without explicit operator confirmation in the most recent
+  message — even on a feature branch the orchestrator has been working on.
+
+## Audit Trail
+
+Every write tool invocation should leave an audit record containing:
+
+- The command and (token-redacted) arguments
+- The target repository and resource (issue / PR number, branch, etc.)
+- The result (success / error, response status, response body summary)
+- The timestamp
+
+Audit records should be observable by the operator (Loki, structured
+stderr, file). Tool output returned to the model is not sufficient — it
+disappears from the conversation.
+
+## Anti-Patterns (orchestrator-only)
+
+- Acting on a write request without checking the repo allowlist first
+- Returning unredacted tool output to the model
+- Inferring mutation consent from earlier conversation rather than the
+  most recent operator message
+- Resolving Copilot review threads autonomously
+- Calling `gh pr merge` / `gh pr ready` even on a green PR
+- Pushing code without explicit operator confirmation
+- Logging full command lines (including token values) for audit

--- a/claude/skills/github/orchestrator.md
+++ b/claude/skills/github/orchestrator.md
@@ -57,6 +57,15 @@ Rules:
 If the operator's most recent message does not literally describe the
 write you're considering, refuse and ask.
 
+**Pending-confirmation exception**: when a high-risk mutation (see next
+section) is awaiting a separate confirmation, the literal-description
+requirement is satisfied by the *prior* operator message that proposed
+the action — the confirmation message itself does not need to repeat the
+description. Example sequence: operator says "Chips, close issue #99" →
+orchestrator asks "confirm close of issue #99?" → operator says "yes".
+The "yes" turn satisfies the universal rule via the prior turn that
+proposed the close.
+
 ## High-Risk Mutations — Additional Confirmation Required
 
 Even when the operator's most recent message describes the action,
@@ -85,8 +94,10 @@ confirmation.
 The universal Copilot Review Workflow in `SKILL.md` applies, with an
 additional gate:
 
-- NEVER autonomously resolve Copilot review threads. Always reply with a
-  fix-commit reference; the operator resolves.
+- NEVER autonomously resolve Copilot review threads. Reply per the
+  universal workflow in `SKILL.md` (citing a fix-commit SHA when changes
+  were made; disagree-only replies are valid without a SHA); the operator
+  resolves the thread.
 - "Apply all suggestions" is not a valid action without explicit operator
   consent on each comment.
 

--- a/claude/skills/github/orchestrator.md
+++ b/claude/skills/github/orchestrator.md
@@ -35,25 +35,50 @@ orchestrator's allowlist before invoking the underlying tool.
 - Command lines logged for audit purposes must be token-redacted at log
   time, not at display time.
 
-## Mutation Gating — Explicit Confirmation
+## Write Operations — Operator Intent Required (Universal Layer)
 
-State-change mutations require explicit confirmation in the operator's
-most recent message:
+Every write operation must reflect intent in the operator's most recent
+message. The user's request itself is the consent for that operation —
+e.g. "Chips, file an issue against bridge titled X" is sufficient consent
+to create the issue, no separate confirm step needed.
 
-- Closing or reopening an issue
-- Marking a PR ready for review (already universally forbidden by
-  `SKILL.md`, but reinforced here)
-- Pushing code, even to a feature branch
-- Resolving a review thread
-- Editing or deleting issue / PR / comment content
+Applies to ALL writes without exception: issue create / comment / edit,
+PR create / comment / review-reply, label add, milestone change, etc.
 
 Rules:
 
-- Don't infer consent from earlier conversation.
+- Don't infer write consent from earlier conversation. The relevant
+  message is the most recent operator turn.
+- Don't broaden scope ("close all open issues") without explicit
+  confirmation on each target — a literal request is per-target consent;
+  set-quantified requests are not.
 - Ambiguity = ask, don't act.
-- A separate `confirm` boolean (extracted from the operator's words, not
-  auto-filled) is the preferred shape for tool input schemas where
-  applicable.
+
+If the operator's most recent message does not literally describe the
+write you're considering, refuse and ask.
+
+## High-Risk Mutations — Additional Confirmation Required
+
+Even when the operator's most recent message describes the action,
+high-risk mutations require a separate confirmation field/utterance
+because the consequences are unrecoverable, compound, or affect other
+people's expectations:
+
+- Closing or reopening an issue
+- Pushing code (even to a feature branch the orchestrator has been
+  working on)
+- Resolving a review thread
+- Editing or deleting issue / PR / comment content already published
+- Calling `gh pr ready` (also universally forbidden in `SKILL.md`) —
+  refuse outright
+- Calling `gh pr merge` (also universally forbidden in `SKILL.md`) —
+  refuse outright
+
+For tools that support it, prefer a `confirm` boolean in the input
+schema that the persona must extract from the operator's words (not
+auto-fill). For tools listed as "refuse outright", the persona must
+not register them as callable at all, regardless of operator
+confirmation.
 
 ## Copilot Review Threads
 


### PR DESCRIPTION
## Summary

- Pilot of the multi-file skill restructure (#97). Splits `claude/skills/github/SKILL.md` into three audience-specific files following Claude Code's official sibling-file pattern.
- **`SKILL.md`** — universal core that applies wherever this skill is loaded (humans via `/github`, autonomous agents that vendor or link this skill). Covers commits, branches, PRs, Copilot review workflow, labels, **public repo security, sensitive values in command arguments**, file hygiene, anti-patterns. References `operator.md` via markdown link so Claude Code loads it on-demand for human users. Does NOT reference `orchestrator.md`.
- **`operator.md`** (new) — human-only addendum: Claude co-author handling on private repos, hook false-positive workarounds, and a "what moved to universal" pointer. Cross-cutting safety rules (public-repo sanitisation, sensitive-values-in-args) were initially placed here but promoted to `SKILL.md` universal core after Copilot review noted they apply equally to autonomous agents (commit `5387bc9`).
- **`orchestrator.md`** (new) — agent-only addendum: repo allowlist enforcement, token & secret redaction, two-layer mutation gating (universal-layer literal-description rule with a pending-confirmation exception, plus high-risk additional-confirmation list), no-auto-resolve Copilot threads, PR-lifecycle gates, audit trail.
- Asymmetric reference graph keeps audience boundaries clean: human via `/github` sees universal+operator (Claude Code follows the link); an autonomous orchestrator like `klazomenai/bridge`'s Chips persona fetches `SKILL.md` body + `orchestrator.md` by path and never sees `operator.md`.
- Universal SKILL.md branch-type list now includes `ci` (subsumes [#95](https://github.com/Klazomenai/dotfiles/issues/95); [PR #96](https://github.com/Klazomenai/dotfiles/pull/96) can close as no-op once this lands).

## Test plan

- [x] `ls claude/skills/github/` shows three files: `SKILL.md`, `operator.md`, `orchestrator.md`
- [x] `grep -n 'operator.md' claude/skills/github/SKILL.md` confirms the link from `SKILL.md` to `operator.md` exists
- [x] `grep -n 'orchestrator.md' claude/skills/github/SKILL.md` returns nothing — silent reference graph
- [x] `grep -n 'ci' claude/skills/github/SKILL.md | grep -i branch` confirms `ci` is now in branch-type allowlist
- [x] `grep -n '## Public Repo Security' claude/skills/github/SKILL.md` confirms the rule is in universal core (line 91)
- [x] `grep -n '## Sensitive Values' claude/skills/github/SKILL.md` confirms argv secret-handling is in universal core (line 113)
- [ ] Reviewer to verify the universal/operator/orchestrator slicing matches the audience-boundary intent
- [ ] Reviewer to spot-check that no universal rule was accidentally moved to operator.md (cross-cutting rules should stay universal)
- [ ] Reviewer to spot-check the orchestrator.md two-layer mutation gating reads cleanly and the pending-confirmation exception is unambiguous

## Review history

- `cfe7850` — initial restructure
- `5387bc9` — promote Public Repo Security + Sensitive Values to universal; rewrite mutation gating in two layers (3 of 5 round-2 Copilot comments addressed; 2 frontmatter comments pushed back per official Anthropic spec)
- `b60dfdd` — close round-3 Copilot catches: enumerate sanitisation surfaces in universal review-step bullet; add pending-confirmation exception to mutation-gating universal layer; defer Copilot-reply SHA-citation to SKILL.md's conditional rule

Refs #97 #95
