### PR TITLE
feat(skill): Phase 1 — claude/profiles/ + restored github SKILL.md universal core 🎓

### DIFF
--- a/.github/workflows/lint-rule-duplication.yml
+++ b/.github/workflows/lint-rule-duplication.yml
@@ -1,0 +1,23 @@
+name: lint-rule-duplication
+
+on:
+  pull_request:
+    paths:
+      - "claude/CLAUDE.md"
+      - "claude/hooks/**"
+      - "claude/settings.json"
+      - "claude/skills/**"
+      - "claude/profiles/**"
+      - "claude/lint/**"
+      - ".github/workflows/lint-rule-duplication.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Scan for cross-layer rule duplication
+        run: bash claude/lint/check-rule-duplication.sh

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -15,7 +15,7 @@ IMPORTANT: These rules are NON-NEGOTIABLE.
 - NEVER create "master" branch
 - Signed commits (`--gpg-sign`) required
 - Branch naming: `<type>/<issue>-<description>`
-- Branch types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `security`, `spike`
+- Branch types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `ci`, `security`, `spike`
 - NEVER amend commits or force-push — stack separate signed commits, squash on merge
 - Base branch: main | Merge style: squash merge | Delete branch after merge
 - Use `Refs #N` in commits — NEVER `Closes #N` (closing is a merge-time decision)
@@ -25,3 +25,12 @@ IMPORTANT: These rules are NON-NEGOTIABLE.
 - IMPORTANT: After creating a PR, STOP. Provide the PR URL. Do NOT suggest merging.
 - NEVER run `gh pr merge` or `gh pr ready` — merging is a human decision after peer review
 - CI passing does NOT mean ready to merge
+
+## Co-author Handling (private repos)
+- NO Claude co-author line on private-repo commits. Public-repo commits may include it; private-repo commits must not.
+- Check repo visibility with `gh repo view --json isPrivate -q '.isPrivate'` before committing if unsure.
+- The `no-coauthor-private.sh` PreToolUse hook (under `claude/hooks/`) fails closed on `private` and `unknown` visibility — if it blocks a commit, verify visibility rather than bypassing.
+
+## Hook UX
+- The PreToolUse hooks under `claude/hooks/` pattern-match against full command strings, including argv values. Some legitimate commands with rich-text bodies may trigger false positives.
+- Workaround: write the body to a temp file (`tmpfile=$(mktemp)` + heredoc), then pass via the appropriate file flag — `--body-file <path>` for `gh pr create`, or `-F body=@$tmpfile` for `gh api` calls. Clean up the temp file after the call.

--- a/claude/lint/check-rule-duplication.sh
+++ b/claude/lint/check-rule-duplication.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# check-rule-duplication.sh
+#
+# Scans for load-bearing rule strings appearing in 3+ files across the
+# four rule layers — CLAUDE.md (behaviour), hooks/ + settings.json
+# (enforcement), skills/ (workflow knowledge), profiles/ (agent
+# constraints). Warns (does not fail CI).
+#
+# The dedup pass (Phase 3 of the skills-architecture redesign,
+# klazomenai/dotfiles#99) will gradually move each duplicated rule
+# toward its canonical layer:
+#   - Behaviour          → claude/CLAUDE.md
+#   - Enforcement        → claude/hooks/ + claude/settings.json
+#   - Workflow knowledge → claude/skills/<name>/SKILL.md
+#   - Agent constraints  → claude/profiles/
+#
+# Adding patterns is safe — false positives surface as warnings, not
+# failures. To add a pattern, append it to the PATTERNS array below.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+LAYERS=(
+    "claude/CLAUDE.md"
+    "claude/hooks"
+    "claude/settings.json"
+    "claude/skills"
+    "claude/profiles"
+)
+
+PATTERNS=(
+    "Refs #N"
+    "Closes #N"
+    "Fixes #N"
+    "Resolves #N"
+    "--gpg-sign"
+    "Co-Authored-By"
+    "NEVER push to \"main\""
+    "NEVER push to main"
+    "NEVER amend commits"
+    "ALWAYS create PRs as draft"
+    "gh pr merge"
+    "gh pr ready"
+    "no-coauthor-private"
+    "no-push-to-main"
+    "no-rebase"
+)
+
+duplications=0
+
+for pattern in "${PATTERNS[@]}"; do
+    files_matching=()
+    for layer in "${LAYERS[@]}"; do
+        if [[ -d "$layer" ]]; then
+            while IFS= read -r match; do
+                [[ -n "$match" ]] && files_matching+=("$match")
+            done < <(grep -rlF -- "$pattern" "$layer" 2>/dev/null || true)
+        elif [[ -f "$layer" ]]; then
+            if grep -qF -- "$pattern" "$layer" 2>/dev/null; then
+                files_matching+=("$layer")
+            fi
+        fi
+    done
+
+    if [[ ${#files_matching[@]} -ge 3 ]]; then
+        echo "::warning ::Rule pattern \"$pattern\" appears in ${#files_matching[@]} files (3+ duplication):"
+        for f in "${files_matching[@]}"; do
+            echo "  - $f"
+        done
+        duplications=$((duplications + 1))
+    fi
+done
+
+if [[ $duplications -gt 0 ]]; then
+    cat <<'EOF'
+
+Found rule patterns duplicated across 3+ files.
+
+This lint is a Phase 3 transition aid (see klazomenai/dotfiles#99). The
+dedup pass will move each rule toward its canonical layer; until then,
+duplication warnings are informational, not blocking.
+
+To add or refine patterns, edit claude/lint/check-rule-duplication.sh.
+EOF
+fi
+
+# Always exit 0 — this is a warning lint, not a gate.
+exit 0

--- a/claude/lint/check-rule-duplication.sh
+++ b/claude/lint/check-rule-duplication.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 # check-rule-duplication.sh
 #
-# Scans for load-bearing rule strings appearing in 3+ files across the
-# four rule layers — CLAUDE.md (behaviour), hooks/ + settings.json
-# (enforcement), skills/ (workflow knowledge), profiles/ (agent
-# constraints). Warns (does not fail CI).
+# Scans for load-bearing rule strings appearing in 3+ files across four
+# conceptual rule layers (scanned as five roots — hooks/ and
+# settings.json are both enforcement):
+#   - claude/CLAUDE.md           — behaviour
+#   - claude/hooks/              — enforcement (PreToolUse scripts)
+#   - claude/settings.json       — enforcement (permission rules)
+#   - claude/skills/             — workflow knowledge
+#   - claude/profiles/           — agent constraints
+# Warns (does not fail CI).
 #
 # The dedup pass (Phase 3 of the skills-architecture redesign,
 # klazomenai/dotfiles#99) will gradually move each duplicated rule
@@ -64,7 +69,7 @@ for pattern in "${PATTERNS[@]}"; do
     done
 
     if [[ ${#files_matching[@]} -ge 3 ]]; then
-        echo "::warning ::Rule pattern \"$pattern\" appears in ${#files_matching[@]} files (3+ duplication):"
+        echo "::warning::Rule pattern \"$pattern\" appears in ${#files_matching[@]} files (3+ duplication):"
         for f in "${files_matching[@]}"; do
             echo "  - $f"
         done

--- a/claude/profiles/README.md
+++ b/claude/profiles/README.md
@@ -1,0 +1,52 @@
+# claude/profiles/ — agent-only constraints
+
+This directory holds agent-only constraints for autonomous orchestrators
+that consume our skill set. It is **deliberately outside the documented
+Claude Code skill loader's scope** — Claude Code never reads this
+directory.
+
+## Layout
+
+- `_universal.md` — cross-cutting agent rules (allowlist enforcement,
+  redaction, mutation gating with operator-intent + pending-confirmation
+  exception, audit trail, refusal policy). Applied to every persona by
+  any consumer.
+- `<skill-name>.md` — selective per-skill agent addendum. Only present
+  for skills that have substantive agent-specific concerns beyond the
+  universal rules. Skills without an entry here have no addendum (the
+  universal profile still applies).
+
+## Consumers
+
+Today's known consumer: `klazomenai/bridge` — a Go Anthropic-API
+orchestrator that fetches these files via filesystem path at boot and
+concatenates them into each persona's system prompt.
+
+Future consumers (other agent frameworks, hypothetical CI bots, etc.)
+read this directory the same way. The file naming convention
+(`_universal.md` + `<skill-name>.md`) and the contents are stable.
+
+## Authoring
+
+When you find yourself wanting to add a per-skill profile, sense-check:
+
+- Is the rule cross-cutting (applies to multiple or all skills)? Goes
+  in `_universal.md`, not a per-skill file.
+- Is the rule a universal workflow rule that humans need too? Goes in
+  `claude/skills/<name>/SKILL.md`, not here.
+- Is the rule operator-only (Claude Code human user concerns —
+  co-author handling, hook UX)? Goes in `claude/CLAUDE.md`, not here.
+- Is the rule a hard enforcement that a tool registration / hook /
+  permission can express? Use those layers, not this one.
+
+This directory is for what's left: agent behaviour constraints that
+aren't universal workflow knowledge and can't be machine-enforced.
+
+## What this directory is NOT
+
+- It is NOT a Claude Code skill — no frontmatter, no auto-invoke, no
+  `~/.claude/skills/` symlink.
+- It is NOT a place for human-operator UX concerns — those live in
+  `claude/CLAUDE.md`.
+- It is NOT a place for runtime infrastructure details — those live in
+  the consumer (e.g. Bridge's deployment Dockerfile + skill loader).

--- a/claude/profiles/_universal.md
+++ b/claude/profiles/_universal.md
@@ -1,0 +1,130 @@
+# Agent Operating Rules — Universal
+
+This file is the cross-cutting agent profile that applies to every autonomous
+orchestrator persona, regardless of which skills they consume. It is loaded
+alongside any persona's individual skills.
+
+This file is **intentionally not referenced from any `SKILL.md`** — Claude
+Code never auto-loads it. The orchestrator (e.g. `klazomenai/bridge`)
+fetches this file by path at boot and concatenates it onto every persona's
+system prompt before any per-skill content.
+
+The behaviours encoded here are the safety baseline for autonomous-agent
+operation.
+
+## Repo / Resource Allowlist Enforcement
+
+Every write operation must verify the target resource (repository,
+namespace, pipeline, secret path, etc.) is in the orchestrator's allowlist
+before invoking the underlying tool.
+
+- Allowlist is fail-closed: empty list = refuse all writes.
+- Refusal must be visible to the operator with a clear explanation —
+  what was refused, why, and which configured allowlist applies.
+- Read-only operations may have a wider or empty allowlist depending on
+  the orchestrator's configuration — but writes are always gated.
+
+## Token & Secret Redaction
+
+- Tool output returned to the model must be sanitised for tokens, secrets,
+  and other sensitive values before the model sees it.
+- Use the orchestrator's shared redaction layer (e.g. a project-level
+  redaction package) — do not write per-tool ad-hoc filters.
+- Command lines logged for audit purposes must be token-redacted at log
+  time, not at display time.
+- Audit logs are persistent — redaction must happen before the log entry
+  is committed, not after retrieval.
+
+## Write Operations — Operator Intent Required
+
+Every write operation must reflect intent in the operator's most recent
+message. The user's request itself is the consent for that operation —
+e.g. "file an issue against bridge titled X" is sufficient consent to
+create the issue, no separate confirm step needed.
+
+Applies to ALL writes without exception: resource creation, comment
+posting, edit, label addition, status change, pipeline trigger, secret
+write, etc.
+
+Rules:
+
+- Don't infer write consent from earlier conversation. The relevant
+  message is the most recent operator turn.
+- Don't broaden scope ("close all open issues", "delete all stale pods")
+  without explicit confirmation on each target — a literal request is
+  per-target consent; set-quantified requests are not.
+- Ambiguity = ask, don't act.
+
+If the operator's most recent message does not literally describe the
+write you're considering, refuse and ask.
+
+**Pending-confirmation exception**: when a high-risk mutation is awaiting
+a separate confirmation, the literal-description requirement is satisfied
+by the *prior* operator message that proposed the action — the
+confirmation message itself does not need to repeat the description.
+Example sequence: operator says "Chips, close issue #99" → orchestrator
+asks "confirm close of issue #99?" → operator says "yes". The "yes" turn
+satisfies the literal-description rule via the prior turn that proposed
+the close.
+
+## High-Risk Mutations — Additional Confirmation Required
+
+Even when the operator's most recent message describes the action,
+certain mutations require a separate confirmation field/utterance because
+their consequences are unrecoverable, compound, or affect other people's
+expectations:
+
+- Closing or reopening an issue / PR
+- Pushing code (even to a feature branch the orchestrator has been
+  working on)
+- Resolving a review thread
+- Editing or deleting issue / PR / comment content already published
+- Destructive infrastructure operations — see the per-skill profile
+  addendum for skill-specific gates (e.g. `kubectl delete` of stateful
+  resources, `terraform destroy`, `vault token revoke`)
+- Operations that bypass a hook or permission rule
+
+For tools that support it, prefer a `confirm` boolean in the input schema
+that the persona must extract from the operator's words (not auto-fill).
+
+For specific tools listed as "refuse outright" in a per-skill profile
+(e.g. `gh pr merge`, `gh pr ready`), the persona must not register them
+as callable at all, regardless of operator confirmation.
+
+## Audit Trail
+
+Every write tool invocation should leave an audit record containing:
+
+- The command and (token-redacted) arguments
+- The target resource (repo, namespace, path)
+- The result (success / error, response status, response body summary)
+- The timestamp
+
+Audit records should be observable by the operator (Loki, structured
+stderr, file). Tool output returned to the model is not sufficient — it
+disappears from the conversation.
+
+## Refusal Policy
+
+When refusing a write, the persona must:
+
+- State what was refused
+- State why (allowlist, missing confirm, high-risk gate, etc.)
+- Surface the gate to the operator clearly enough that they can override
+  it explicitly if appropriate (rather than the operator having to guess
+  what the gate was)
+
+Don't refuse silently. Don't degrade the response by partially-completing.
+Don't substitute a "safer" action the operator didn't ask for.
+
+## Anti-Patterns
+
+- Acting on a write request without checking the resource allowlist first
+- Returning unredacted tool output to the model
+- Inferring mutation consent from earlier conversation rather than the
+  most recent operator message (or its pending-confirmation predecessor)
+- Logging full command lines (including token values) for audit
+- Refusing silently — every refusal must surface the gate
+- Substituting a "safer" action the operator didn't ask for
+- Treating a tool as callable that the per-skill profile lists as
+  "refuse outright" (the tool must not be registered at all)

--- a/claude/profiles/github.md
+++ b/claude/profiles/github.md
@@ -1,0 +1,75 @@
+# Agent Operating Rules — Git + GitHub Workflow
+
+This file is the github-specific agent profile addendum. It is loaded
+alongside `_universal.md` for any persona that consumes the `github`
+skill.
+
+This file is **intentionally not referenced from
+`claude/skills/github/SKILL.md`** — Claude Code never auto-loads it.
+Orchestrators (e.g. `klazomenai/bridge`) fetch this file by path at boot.
+
+The universal workflow rules in `claude/skills/github/SKILL.md` apply to
+both human Claude Code users and autonomous agents. The cross-cutting
+agent rules in `claude/profiles/_universal.md` apply to every persona
+regardless of skill. The rules below are the github-specific additions
+for autonomous agents.
+
+## PR Lifecycle Gates
+
+The universal SKILL.md says: NEVER run `gh pr merge` or `gh pr ready` —
+merging is a human decision after peer review. For autonomous agents
+this is hardened from a rule to a tool-registration constraint:
+
+- `gh pr merge` and `gh pr ready` must not be exposed as callable tools
+  to the persona. The persona cannot invoke them even with explicit
+  operator confirmation. Removing the tool from the registry is the
+  correct enforcement, not a runtime refusal.
+- `gh pr create` must be exposed only with `--draft` baked in. The
+  tool's input schema must reject `draft=false`.
+
+## Pushing Code
+
+The universal SKILL.md says: don't amend, don't force-push, stack on the
+same branch. For autonomous agents:
+
+- Pushing code (even to a feature branch the orchestrator has been
+  working on) requires explicit operator confirmation per the high-risk
+  mutation gating rule in `_universal.md`. The agent does not infer
+  push consent from "we just made a fix".
+- The agent never invokes `git push --force` or
+  `git push --force-with-lease` regardless of operator confirmation —
+  these are refused outright.
+
+## Copilot Review Threads
+
+The universal SKILL.md describes the read → discuss → user-decides →
+fix → test → push → reply workflow. For autonomous agents:
+
+- NEVER autonomously resolve Copilot review threads. Reply per the
+  universal workflow (citing a fix-commit SHA when changes were made;
+  disagree-only replies are valid without a SHA); the operator resolves
+  the thread.
+- "Apply all suggestions" is not a valid action without explicit
+  operator consent on each comment.
+- Always present each top-level Copilot comment to the operator with
+  the agent's assessment (agree / disagree / partial); do not silently
+  filter comments out.
+
+## Branch Operations
+
+- The agent never creates a `master` branch. Refused outright.
+- The agent never pushes to `main` or the default branch. Refused
+  outright, regardless of operator confirmation.
+- The agent never amends commits during PR review or rebases a
+  published branch. Refused outright.
+
+## Anti-Patterns
+
+- Resolving Copilot review threads autonomously
+- Calling `gh pr merge` or `gh pr ready` (these tools must not be
+  registered)
+- Calling `gh pr create` without `--draft`
+- Creating non-draft PRs through any path
+- Pushing code without explicit operator confirmation
+- Force-pushing or rebasing published branches
+- Amending commits during PR review

--- a/claude/profiles/github.md
+++ b/claude/profiles/github.md
@@ -1,6 +1,6 @@
 # Agent Operating Rules — Git + GitHub Workflow
 
-This file is the github-specific agent profile addendum. It is loaded
+This file is the GitHub-specific agent profile addendum. It is loaded
 alongside `_universal.md` for any persona that consumes the `github`
 skill.
 
@@ -11,7 +11,7 @@ Orchestrators (e.g. `klazomenai/bridge`) fetch this file by path at boot.
 The universal workflow rules in `claude/skills/github/SKILL.md` apply to
 both human Claude Code users and autonomous agents. The cross-cutting
 agent rules in `claude/profiles/_universal.md` apply to every persona
-regardless of skill. The rules below are the github-specific additions
+regardless of skill. The rules below are the GitHub-specific additions
 for autonomous agents.
 
 ## PR Lifecycle Gates

--- a/claude/skills/github/SKILL.md
+++ b/claude/skills/github/SKILL.md
@@ -47,7 +47,7 @@ loads that directory.
   ## Test plan
   - [ ] Bulleted checklist of testing TODOs
   ```
-- Use temp files for PR bodies to avoid hook false positives: write body to file, then `gh pr create --body-file path/to/file --draft ...`. (Note: `--body-file <path>` is the `gh pr create` flag; the `-F body=@file` form-field syntax is for `gh api` calls only — see PR Review Replies below.)
+- Write PR bodies to temp files for safe escaping of complex content: `gh pr create --body-file path/to/file --draft ...`. (Note: `--body-file <path>` is the `gh pr create` flag; the `-F body=@file` form-field syntax is for `gh api` calls only — see PR Review Replies below.)
 
 ## Issue Conventions
 
@@ -84,7 +84,7 @@ Rules:
 
 When replying to PR review comments:
 
-- Write reply body to a temp file first to avoid hook false positives on `gh api` body content
+- Write reply body to a temp file for safe escaping of complex content
 - Pattern: `tmpfile=$(mktemp) && cat <<'EOF' > "$tmpfile" ... EOF` then `gh api ... -F "body=@$tmpfile" -F in_reply_to=<id> && rm -f "$tmpfile"`
 - Always reply inline to the specific comment thread, not as a standalone comment
 

--- a/claude/skills/github/SKILL.md
+++ b/claude/skills/github/SKILL.md
@@ -5,13 +5,20 @@ description: Git and GitHub workflow guidance, including commits, branches, PRs,
 
 # Git + GitHub Skill
 
+This skill encodes the universal git + GitHub workflow rules — they apply
+wherever this skill is loaded, including by autonomous agents that vendor
+or link this file. Operator-specific concerns (Claude co-author handling on
+private repos, hook UX) live in `claude/CLAUDE.md`. Agent-specific
+constraints (allowlist enforcement, mutation gating, no-autonomous-merge)
+live in `claude/profiles/` for orchestrator consumers — Claude Code never
+loads that directory.
+
 ## Commit Conventions
 
 - Conventional commits format: `<type>(scope): description`
 - Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `ci`, `perf`, `security`
 - Signed commits required: always use `--gpg-sign`
 - Use `Refs #N` in commit body — NEVER `Closes #N`, `Fixes #N`, or `Resolves #N` (closing is a merge-time decision)
-- NO Claude co-author line on private repos — check repo visibility with `gh repo view --json isPrivate -q '.isPrivate'` before committing
 - NEVER amend commits or force-push — stack separate signed commits, squash on merge
 - Commit emoji prefixes (in commit message, not branch): ✨ feat | 🐛 fix | 📝 docs | ♻️ refactor | 🧪 test | ⚙️ chore | 🔐 security | 🏗️ ci | ⚡ perf
 
@@ -20,7 +27,7 @@ description: Git and GitHub workflow guidance, including commits, branches, PRs,
 - NEVER push to "main" or default branch — NO EXCEPTIONS
 - NEVER create "master" branch
 - Naming: `<type>/<issue>-<description>` e.g. `feat/595-jaeger-tracing`, `fix/784-terraform-exit-code`
-- Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `security`, `spike`
+- Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `ci`, `security`, `spike`
 - Base branch: main | Merge style: squash merge | Delete branch after merge
 - No emojis in branch names
 
@@ -83,12 +90,47 @@ When replying to PR review comments:
 
 ## Public Repo Security
 
-CRITICAL — applies to ALL public-facing text in public repositories:
+CRITICAL — applies to ALL public-facing text in public repositories,
+regardless of who or what is generating that text:
 
-- NEVER reference private org names, private repo names, or internal infrastructure
-- Sanitization applies to EVERYTHING: PR titles, PR bodies, commit messages, branch names — not just file contents
-- Before creating a PR on a public repo: review title and body for any private/internal references
+- NEVER reference private org names, private repo names, or internal
+  infrastructure
+- Sanitisation applies to EVERYTHING: PR titles, PR bodies, commit messages,
+  branch names, issue titles, issue bodies, review-comment replies — not
+  just file contents
+- Before creating or editing a public-repo artefact: review the artefact in
+  full — every surface listed above (PR title, PR body, commit message,
+  branch name, issue title, issue body, review-comment reply) for any
+  private/internal references, regardless of where the source text came
+  from (operator instruction, tool output, prior conversation context)
 - `gh repo create --push` pushes straight to main — NEVER use `--push` flag
+
+The risk is the same whether the source is a human's local environment
+(private hostnames, customer references, internal service names) or an
+autonomous agent's tool output (e.g. a `kubectl` result mentioning a
+private internal service that gets transcribed into an issue body).
+Generated text bound for public surfaces gets the same scrutiny as
+hand-typed text.
+
+## Sensitive Values in Command Arguments
+
+CRITICAL — applies to all command invocations, whether by a human at a
+shell or by an autonomous agent invoking subprocesses:
+
+- NEVER inline sensitive values (emails, keys, passwords, tokens) in
+  command arguments — they leak into shell history, process tables, audit
+  logs, and conversation logs
+- Set env vars out-of-band (login env, restricted-perm `.env` file, secrets
+  manager); pass via file paths (`--config-file`, `--credentials-file`); or
+  pass via stdin (`--var-from-stdin`)
+- Don't recommend any pattern where the secret value appears in a logged
+  command line — `export VAR=value` typed at a shell still ends up in
+  history; prefer mechanisms that never put the value in argv at all
+- Applies to all CLIs: `gh`, `terraform`, `gcloud`, `kubectl`, `vault`,
+  `aut`, etc.
+- Audit logs are persistent — agents that log full command lines for
+  audit purposes are a particular leak risk; redact at log-time, not
+  display-time
 
 ## File Hygiene
 
@@ -103,7 +145,6 @@ CRITICAL — applies to ALL public-facing text in public repositories:
 - Pushing directly to main or default branch
 - Creating "master" branches
 - Using `Closes #N`, `Fixes #N`, or `Resolves #N` in commit messages (use `Refs #N`)
-- Adding Claude co-author to private repo commits
 - Using `gh pr merge` or `gh pr ready` (merging is a human decision)
 - Creating non-draft PRs
 - Committing secrets or credentials

--- a/claude/skills/github/SKILL.md
+++ b/claude/skills/github/SKILL.md
@@ -121,8 +121,10 @@ shell or by an autonomous agent invoking subprocesses:
   command arguments — they leak into shell history, process tables, audit
   logs, and conversation logs
 - Set env vars out-of-band (login env, restricted-perm `.env` file, secrets
-  manager); pass via file paths (`--config-file`, `--credentials-file`); or
-  pass via stdin (`--var-from-stdin`)
+  manager); pass via file paths (`gh auth login --with-token < tokenfile`,
+  `kubectl create secret generic --from-file=key=/dev/stdin`); or pipe via
+  stdin where the tool supports it (`docker login --password-stdin`,
+  `helm registry login --password-stdin`)
 - Don't recommend any pattern where the secret value appears in a logged
   command line — `export VAR=value` typed at a shell still ends up in
   history; prefer mechanisms that never put the value in argv at all


### PR DESCRIPTION
## Summary

- Phase 1 of the skills architecture redesign ([#99](https://github.com/Klazomenai/dotfiles/issues/99)). Establishes the parallel `claude/profiles/` namespace for autonomous-agent-only constraints; restores `claude/skills/github/SKILL.md` to universal-core shape with all four Copilot-driven improvements from the superseded [PR #98](https://github.com/Klazomenai/dotfiles/pull/98) baked in; absorbs operator-only rules into `claude/CLAUDE.md`; adds CI lint detecting cross-layer rule duplication.
- `claude/profiles/` is intentionally outside the documented Claude Code skill loader's scope — Claude Code never reads this directory. Bridge fetches by path. See [`claude/profiles/README.md`](claude/profiles/README.md) for the consumption model.
- `claude/skills/github/SKILL.md` ships as universal-core only — no operator/orchestrator siblings. Operator-only content (Claude co-author rule, hook UX) absorbed into `claude/CLAUDE.md`. Subsumes [#95](https://github.com/Klazomenai/dotfiles/issues/95) (`ci` branch type) — [PR #96](https://github.com/Klazomenai/dotfiles/pull/96) can close as no-op once this lands.
- CI lint emits `::warning::` annotations when a load-bearing rule pattern appears in 3+ files across CLAUDE.md / hooks / settings.json / skills / profiles. Phase 3 dedup follow-ups will gradually move each rule to its canonical layer. Local dry-run already flags 5 patterns (`Refs #N`, `Closes #N`, `--gpg-sign`, `gh pr merge`, `gh pr ready`) — those are the targets for Phase 3.

## Test plan

- [x] `ls claude/skills/github/` shows only `SKILL.md` (no operator/orchestrator siblings)
- [x] `grep -n 'ci' claude/skills/github/SKILL.md | grep -i branch` confirms `ci` in branch types
- [x] `grep -n 'Sensitive Values\|Public Repo Security' claude/skills/github/SKILL.md` confirms both sections in universal core
- [x] `grep -n 'export VAR=value' claude/skills/github/SKILL.md` finds the leak warning, not a recommendation
- [x] `grep -n 'review-comment reply\|review reply' claude/skills/github/SKILL.md` confirms sanitisation surfaces enumerated
- [x] `ls claude/profiles/` shows `_universal.md`, `github.md`, `README.md`
- [x] `grep -n 'co-author\|Co-Authored-By' claude/skills/github/SKILL.md` returns nothing — operator concern moved to CLAUDE.md
- [x] `bash claude/lint/check-rule-duplication.sh` runs locally, emits warnings, exits 0
- [ ] Reviewer to verify the universal/operator/agent slicing matches the audience-boundary intent
- [ ] Reviewer to spot-check the new `claude/profiles/_universal.md` content reads cleanly and the pending-confirmation exception is unambiguous
- [ ] Reviewer to spot-check the `claude/profiles/github.md` covers the github-specific agent gates without overlapping the universal SKILL.md
- [ ] CI: `lint-rule-duplication.yml` runs on this PR; check that the warning annotations surface the expected duplications

## Out of scope

- Bridge consumer changes — sibling [klazomenai/bridge#147](https://github.com/Klazomenai/bridge/issues/147) / sub-issue [#148](https://github.com/Klazomenai/bridge/issues/148) covers the loader implementation
- Phase 2 per-skill profile addenda for `kubernetes`, `concourse`, `vault`, `security`, `terraform`, `nix-modules-hardening` — pre-filed sub-issues [#101](https://github.com/Klazomenai/dotfiles/issues/101)–[#106](https://github.com/Klazomenai/dotfiles/issues/106), each ships independently
- Phase 3 actual dedup pass — deferred follow-ups; this PR ships the CI lint that surfaces the targets

Refs #99 #100 #95
