### PR TITLE
chore(test): L0 skill structure fixture script + make target 🧪

### DIFF
--- a/.github/workflows/lint-skill-structure.yml
+++ b/.github/workflows/lint-skill-structure.yml
@@ -1,0 +1,20 @@
+name: lint-skill-structure
+
+on:
+  pull_request:
+    paths:
+      - "claude/skills/**"
+      - "claude/profiles/**"
+      - "scripts/check-skill-structure.sh"
+      - ".github/workflows/lint-skill-structure.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run L0 skill structure fixture
+        run: bash scripts/check-skill-structure.sh

--- a/.github/workflows/lint-skill-structure.yml
+++ b/.github/workflows/lint-skill-structure.yml
@@ -17,4 +17,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run L0 skill structure fixture
-        run: bash scripts/check-skill-structure.sh
+        run: sh scripts/check-skill-structure.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install-claude bin-version-check bin-paths-check all-checks
+.PHONY: help install-claude bin-version-check bin-paths-check check-skills all-checks
 
 # Default target
 .DEFAULT_GOAL := help
@@ -163,6 +163,11 @@ install-claude: ## Symlink Claude Code configuration to ~/.claude
 	@ln -sfn "$(CURDIR)/claude/skills" "$(HOME)/.claude/skills"
 	@printf "$(COLOR_GREEN)✅ Claude Code configuration linked to $(HOME)/.claude$(COLOR_RESET)\n"
 
-all-checks: bin-paths-check bin-version-check ## Run all validation checks
+check-skills: ## Run L0 static-structure check on claude/skills/ + claude/profiles/
+	@echo "🔍 Checking skill + profile directory structure..."
+	@bash scripts/check-skill-structure.sh
+	@printf "$(COLOR_GREEN)✅ Skill structure verified$(COLOR_RESET)\n"
+
+all-checks: bin-paths-check bin-version-check check-skills ## Run all validation checks
 	@echo ""
 	@printf "$(COLOR_GREEN)✅ All checks passed!$(COLOR_RESET)\n"

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ install-claude: ## Symlink Claude Code configuration to ~/.claude
 
 check-skills: ## Run L0 static-structure check on claude/skills/ + claude/profiles/
 	@echo "🔍 Checking skill + profile directory structure..."
-	@bash scripts/check-skill-structure.sh
+	@sh scripts/check-skill-structure.sh
 	@printf "$(COLOR_GREEN)✅ Skill structure verified$(COLOR_RESET)\n"
 
 all-checks: bin-paths-check bin-version-check check-skills ## Run all validation checks

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ help: ## Display this help message
 	@grep -E '^install-.*:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(COLOR_BLUE)%-25s$(COLOR_RESET) %s\n", $$1, $$2}'
 	@echo ""
 	@echo "✅ VALIDATION:"
-	@grep -E '^(bin-version-check|bin-paths-check|all-checks):.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(COLOR_BLUE)%-25s$(COLOR_RESET) %s\n", $$1, $$2}'
+	@grep -E '^(bin-version-check|bin-paths-check|check-skills|all-checks):.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(COLOR_BLUE)%-25s$(COLOR_RESET) %s\n", $$1, $$2}'
 	@echo ""
 	@echo "Fair seas and following winds ⚓🌊⛵"
 	@echo ""

--- a/scripts/check-skill-structure.sh
+++ b/scripts/check-skill-structure.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env sh
+# check-skill-structure.sh
+#
+# L0 static-structure fixture for the Chips skills architecture (see
+# klazomenai/dotfiles#99). Asserts that the dotfiles repo's skills +
+# profiles directories are structurally correct so downstream consumers
+# (Bridge orchestrator, autonomous agents) can rely on them.
+#
+# What it checks:
+#   1. Every directory under claude/skills/ contains a SKILL.md
+#   2. claude/profiles/_universal.md exists with the required H2 sections
+#   3. claude/profiles/github.md exists with the required H2 sections
+#   4. No claude/skills/<name>/SKILL.md references _universal.md
+#      (negative claim — the asymmetric reference graph is deliberate;
+#      Claude Code must not auto-load universal content via a sibling
+#      link from a SKILL.md, since that would pollute human-CC users
+#      with orchestrator-only constraints)
+#
+# Exits 0 on success, non-zero on the first failure with a clear message.
+# Designed for CI-friendly output; uses ::error:: workflow-command format
+# when running under GitHub Actions (detected via $GITHUB_ACTIONS).
+#
+# POSIX shell — no jq, no yq, no bash-only constructs.
+
+set -eu
+
+# Locate repo root (script lives at <repo>/scripts/).
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd)
+cd "${REPO_ROOT}"
+
+# Output helpers — surface as GitHub Actions annotations when possible.
+fail() {
+    if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+        printf '::error::%s\n' "$1"
+    else
+        printf 'FAIL: %s\n' "$1" >&2
+    fi
+    exit 1
+}
+
+info() {
+    printf '%s\n' "$1"
+}
+
+# ------------------------------------------------------------------
+# Check 1 — every claude/skills/<name>/ has a SKILL.md
+# ------------------------------------------------------------------
+info "Checking claude/skills/*/SKILL.md presence..."
+missing=0
+for dir in claude/skills/*/; do
+    [ -d "$dir" ] || continue
+    if [ ! -f "${dir}SKILL.md" ]; then
+        fail "skill directory ${dir} is missing SKILL.md"
+        missing=$((missing + 1))
+    fi
+done
+[ "$missing" -eq 0 ] || exit 1
+
+# ------------------------------------------------------------------
+# Check 2 — _universal.md required H2 sections
+# ------------------------------------------------------------------
+UNIVERSAL_PATH="claude/profiles/_universal.md"
+info "Checking ${UNIVERSAL_PATH} sections..."
+[ -f "${UNIVERSAL_PATH}" ] || fail "${UNIVERSAL_PATH} does not exist"
+
+# Required H2 section headings (must appear at the start of a line as `## `).
+# Stored newline-separated for POSIX iteration.
+universal_required="Repo / Resource Allowlist Enforcement
+Token & Secret Redaction
+Write Operations — Operator Intent Required
+High-Risk Mutations — Additional Confirmation Required
+Audit Trail
+Refusal Policy
+Anti-Patterns"
+
+printf '%s\n' "$universal_required" | while IFS= read -r section; do
+    [ -n "$section" ] || continue
+    if ! grep -qF "## ${section}" "${UNIVERSAL_PATH}"; then
+        fail "${UNIVERSAL_PATH} missing required section: ## ${section}"
+    fi
+done
+
+# ------------------------------------------------------------------
+# Check 3 — github.md required H2 sections
+# ------------------------------------------------------------------
+GITHUB_PROFILE_PATH="claude/profiles/github.md"
+info "Checking ${GITHUB_PROFILE_PATH} sections..."
+[ -f "${GITHUB_PROFILE_PATH}" ] || fail "${GITHUB_PROFILE_PATH} does not exist"
+
+github_profile_required="PR Lifecycle Gates
+Pushing Code
+Copilot Review Threads
+Branch Operations
+Anti-Patterns"
+
+printf '%s\n' "$github_profile_required" | while IFS= read -r section; do
+    [ -n "$section" ] || continue
+    if ! grep -qF "## ${section}" "${GITHUB_PROFILE_PATH}"; then
+        fail "${GITHUB_PROFILE_PATH} missing required section: ## ${section}"
+    fi
+done
+
+# ------------------------------------------------------------------
+# Check 4 — no SKILL.md references _universal.md (negative claim)
+# ------------------------------------------------------------------
+info "Checking no SKILL.md references _universal.md..."
+violators=$(grep -rlF "_universal.md" claude/skills/ 2>/dev/null || true)
+if [ -n "$violators" ]; then
+    fail "claude/skills/ files reference _universal.md (would auto-load orchestrator content for human Claude Code users — see #99 architecture decision):
+${violators}"
+fi
+
+# ------------------------------------------------------------------
+info "All L0 skill-structure checks passed."
+exit 0

--- a/scripts/check-skill-structure.sh
+++ b/scripts/check-skill-structure.sh
@@ -30,11 +30,20 @@ REPO_ROOT=$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd)
 cd "${REPO_ROOT}"
 
 # Output helpers — surface as GitHub Actions annotations when possible.
+# fail emits a single-line ::error:: annotation under GHA so the workflow
+# command parses correctly. Multi-line context (file lists, etc.) goes to
+# stderr separately to preserve the annotation while still surfacing
+# diagnostic data in the run log.
 fail() {
     if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
         printf '::error::%s\n' "$1"
     else
         printf 'FAIL: %s\n' "$1" >&2
+    fi
+    # Optional second argument: multi-line diagnostic to print to stderr
+    # (e.g. list of violating files) without breaking the annotation.
+    if [ "$#" -ge 2 ] && [ -n "$2" ]; then
+        printf '%s\n' "$2" >&2
     fi
     exit 1
 }
@@ -74,12 +83,18 @@ Audit Trail
 Refusal Policy
 Anti-Patterns"
 
-printf '%s\n' "$universal_required" | while IFS= read -r section; do
+# Loop over required sections in the parent shell (no pipeline subshell —
+# `printf | while` runs in a subshell on POSIX sh, so `fail`/`exit` would
+# only kill the subshell and the outer script would silently succeed).
+# Here-doc redirect keeps the loop in the parent shell.
+while IFS= read -r section; do
     [ -n "$section" ] || continue
-    if ! grep -qF "## ${section}" "${UNIVERSAL_PATH}"; then
+    if ! grep -qxF "## ${section}" "${UNIVERSAL_PATH}"; then
         fail "${UNIVERSAL_PATH} missing required section: ## ${section}"
     fi
-done
+done <<EOF
+${universal_required}
+EOF
 
 # ------------------------------------------------------------------
 # Check 3 — github.md required H2 sections
@@ -94,20 +109,27 @@ Copilot Review Threads
 Branch Operations
 Anti-Patterns"
 
-printf '%s\n' "$github_profile_required" | while IFS= read -r section; do
+while IFS= read -r section; do
     [ -n "$section" ] || continue
-    if ! grep -qF "## ${section}" "${GITHUB_PROFILE_PATH}"; then
+    if ! grep -qxF "## ${section}" "${GITHUB_PROFILE_PATH}"; then
         fail "${GITHUB_PROFILE_PATH} missing required section: ## ${section}"
     fi
-done
+done <<EOF
+${github_profile_required}
+EOF
 
 # ------------------------------------------------------------------
 # Check 4 — no SKILL.md references _universal.md (negative claim)
 # ------------------------------------------------------------------
+# Restricted to SKILL.md files specifically. Future README.md or notes
+# under a skill directory may legitimately mention _universal.md (e.g.
+# a "this skill has no profile addendum" note); only SKILL.md must
+# avoid the link, since those are the files Claude Code parses for
+# the auto-loaded reference graph.
 info "Checking no SKILL.md references _universal.md..."
-violators=$(grep -rlF "_universal.md" claude/skills/ 2>/dev/null || true)
+violators=$(find claude/skills -type f -name SKILL.md -exec grep -lF "_universal.md" {} + 2>/dev/null || true)
 if [ -n "$violators" ]; then
-    fail "claude/skills/ files reference _universal.md (would auto-load orchestrator content for human Claude Code users — see #99 architecture decision):
+    fail "claude/skills/ SKILL.md files reference _universal.md (would auto-load orchestrator content for human Claude Code users — see #99 architecture decision)" "violating files:
 ${violators}"
 fi
 

--- a/scripts/check-skill-structure.sh
+++ b/scripts/check-skill-structure.sh
@@ -24,9 +24,12 @@
 
 set -eu
 
-# Locate repo root (script lives at <repo>/scripts/).
-SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-REPO_ROOT=$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd)
+# Locate repo root (script lives at <repo>/scripts/). The `$0` value is
+# the script's own path; it cannot start with `-`, so the `--` end-of-
+# options marker isn't needed and is dropped here for portability with
+# non-GNU userlands where `dirname --` / `cd --` may not be supported.
+SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd "${SCRIPT_DIR}/.." && pwd)
 cd "${REPO_ROOT}"
 
 # Output helpers — surface as GitHub Actions annotations when possible.
@@ -55,16 +58,29 @@ info() {
 # ------------------------------------------------------------------
 # Check 1 — every claude/skills/<name>/ has a SKILL.md
 # ------------------------------------------------------------------
+# Pre-flight: claude/skills/ must exist and contain at least one
+# directory. Without this, an unmatched glob (`claude/skills/*/`) stays
+# literal in POSIX sh and the loop body silently never executes.
 info "Checking claude/skills/*/SKILL.md presence..."
-missing=0
-for dir in claude/skills/*/; do
-    [ -d "$dir" ] || continue
-    if [ ! -f "${dir}SKILL.md" ]; then
-        fail "skill directory ${dir} is missing SKILL.md"
-        missing=$((missing + 1))
+[ -d "claude/skills" ] || fail "claude/skills/ directory does not exist"
+skill_dirs=$(find claude/skills -mindepth 1 -maxdepth 1 -type d)
+[ -n "$skill_dirs" ] || fail "claude/skills/ contains no skill directories"
+
+# Collect ALL missing SKILL.md files first, then fail once with the full
+# list — operator-friendly: see every problem in a single run rather
+# than fix-one-rerun loops. (`fail` itself still exits on first call;
+# we just defer it until after the loop.)
+missing_skills=""
+for dir in $skill_dirs; do
+    if [ ! -f "${dir}/SKILL.md" ]; then
+        missing_skills="${missing_skills}${dir}/SKILL.md
+"
     fi
 done
-[ "$missing" -eq 0 ] || exit 1
+if [ -n "$missing_skills" ]; then
+    fail "one or more skill directories are missing SKILL.md" "missing files:
+${missing_skills}"
+fi
 
 # ------------------------------------------------------------------
 # Check 2 — _universal.md required H2 sections
@@ -126,8 +142,22 @@ EOF
 # a "this skill has no profile addendum" note); only SKILL.md must
 # avoid the link, since those are the files Claude Code parses for
 # the auto-loaded reference graph.
+#
+# Per-file grep -q (in an `if` clause, so its non-zero "no match" exit
+# is consumed by the conditional rather than tripping `set -e`).
+# `find` errors still propagate naturally — only the grep "no match"
+# case is consumed.
 info "Checking no SKILL.md references _universal.md..."
-violators=$(find claude/skills -type f -name SKILL.md -exec grep -lF "_universal.md" {} + 2>/dev/null || true)
+violators=""
+while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    if grep -qF "_universal.md" "$f"; then
+        violators="${violators}${f}
+"
+    fi
+done <<EOF
+$(find claude/skills -type f -name SKILL.md)
+EOF
 if [ -n "$violators" ]; then
     fail "claude/skills/ SKILL.md files reference _universal.md (would auto-load orchestrator content for human Claude Code users — see #99 architecture decision)" "violating files:
 ${violators}"

--- a/scripts/check-skill-structure.sh
+++ b/scripts/check-skill-structure.sh
@@ -58,25 +58,33 @@ info() {
 # ------------------------------------------------------------------
 # Check 1 — every claude/skills/<name>/ has a SKILL.md
 # ------------------------------------------------------------------
-# Pre-flight: claude/skills/ must exist and contain at least one
-# directory. Without this, an unmatched glob (`claude/skills/*/`) stays
-# literal in POSIX sh and the loop body silently never executes.
+# Pre-flight: claude/skills/ must exist. Beyond that, we enumerate
+# child directories via a POSIX glob (`claude/skills/*/`) — `find` with
+# -mindepth/-maxdepth is GNU/BSD-only, not POSIX. The `[ -d "$dir" ]`
+# guard handles the unmatched-glob-stays-literal case (POSIX sh leaves
+# the pattern unchanged when no files match), and `found_any` catches
+# the empty-directory case explicitly so a deleted skills/ still fails
+# CI rather than silently passing.
 info "Checking claude/skills/*/SKILL.md presence..."
 [ -d "claude/skills" ] || fail "claude/skills/ directory does not exist"
-skill_dirs=$(find claude/skills -mindepth 1 -maxdepth 1 -type d)
-[ -n "$skill_dirs" ] || fail "claude/skills/ contains no skill directories"
 
 # Collect ALL missing SKILL.md files first, then fail once with the full
 # list — operator-friendly: see every problem in a single run rather
-# than fix-one-rerun loops. (`fail` itself still exits on first call;
-# we just defer it until after the loop.)
+# than fix-one-rerun loops.
 missing_skills=""
-for dir in $skill_dirs; do
-    if [ ! -f "${dir}/SKILL.md" ]; then
-        missing_skills="${missing_skills}${dir}/SKILL.md
+found_any=0
+for dir in claude/skills/*/; do
+    [ -d "$dir" ] || continue
+    found_any=1
+    skill_md="${dir}SKILL.md"
+    if [ ! -f "$skill_md" ]; then
+        missing_skills="${missing_skills}${skill_md}
 "
     fi
 done
+
+[ "$found_any" -eq 1 ] || fail "claude/skills/ contains no skill directories"
+
 if [ -n "$missing_skills" ]; then
     fail "one or more skill directories are missing SKILL.md" "missing files:
 ${missing_skills}"


### PR DESCRIPTION
## Summary

- Phase A of the Chips Skills Architecture E2E Test effort ([#109](https://github.com/Klazomenai/dotfiles/issues/109), parent [#99](https://github.com/Klazomenai/dotfiles/issues/99)).
- New `scripts/check-skill-structure.sh` — POSIX shell, no `jq`/`yq` dependencies. Asserts every `claude/skills/<name>/` directory contains a `SKILL.md`; `claude/profiles/_universal.md` has all 7 required H2 sections; `claude/profiles/github.md` has all 5 required H2 sections; no `SKILL.md` references `_universal.md` (negative claim — the asymmetric reference graph is deliberate, Claude Code must not auto-load orchestrator content for human CLI users via a sibling link).
- Surfaces failures as `::error::` GitHub Actions annotations under `$GITHUB_ACTIONS`, plain stderr otherwise.
- New `make check-skills` target invokes the script; folded into the existing `make all-checks` so the standard validation flow now includes structural verification.
- New `.github/workflows/lint-skill-structure.yml` runs the script on PRs touching `claude/skills/**` or `claude/profiles/**` (or the script/workflow themselves).

## Test plan

- [x] `bash scripts/check-skill-structure.sh` on clean main → exits 0
- [x] `make check-skills` runs and reports green
- [ ] Reviewer to spot-check the negative test by temporarily breaking a section header in `claude/profiles/_universal.md` locally and rerunning the script — should exit non-zero with a clear message
- [ ] CI on this PR: `lint-skill-structure` workflow runs and passes
- [ ] Reviewer to verify the required-section lists in the script match the current `_universal.md` and `github.md` headings on main (no drift between fixture and source)

Refs #99 #109
