### PR TITLE
feat(skill): Phase 2 — claude/profiles/security.md 🎓

### DIFF
--- a/claude/profiles/security.md
+++ b/claude/profiles/security.md
@@ -27,13 +27,12 @@ not as an invitation to ask "what does the operator most likely want?"
 
 ## Defense in Depth
 
-Defense in depth combines domain-level safety (the patterns in
-`claude/skills/security/SKILL.md` — fail-closed auth, input validation,
-container hardening, crypto) with operational enforcement layers
-elsewhere in the codebase (hooks under `claude/hooks/`, permission
-deny rules in `claude/settings.json`, allowlist enforcement described
-in `_universal.md`). Each layer is load-bearing — none is a backup
-for another:
+Defense in depth combines three categories of safety: domain-level
+patterns in `claude/skills/security/SKILL.md` (fail-closed auth, input
+validation, container hardening, crypto), operational enforcement in
+`claude/hooks/` (PreToolUse scripts) and `claude/settings.json`
+(permission deny rules), and the cross-cutting model-posture rules in
+`_universal.md`. Each is load-bearing — none is a backup for another:
 
 - Never recommend disabling one safety layer because another covers it.
   Layers are independent and additive by design — removing one weakens
@@ -87,12 +86,12 @@ Refuse outright, regardless of operator request:
   operator-supplied or externally supplied content
 - Disabling input validation, schema checks, or type assertions —
   "temporarily" or otherwise
-- Path construction from external input without the full join-clean-
-  reject pattern from the security SKILL.md (join against an allowed
-  base, `filepath.Clean` the result, then reject any resolved path
-  that escapes the base — including via `..` traversal or symlink
-  resolution); `filepath.Clean` alone is not sufficient; accepting
-  absolute paths from external input as-is
+- Path construction from external input without the full
+  join-clean-reject pattern from the security SKILL.md (join against
+  an allowed base, `filepath.Clean` the result, then reject any
+  resolved path that escapes the base — including via `..` traversal
+  or symlink resolution); `filepath.Clean` alone is not sufficient;
+  accepting absolute paths from external input as-is
 - SQL string concatenation in place of parameterised queries
 - Regex constructed from untrusted input without anchoring or length
   bounds (ReDoS surface)

--- a/claude/profiles/security.md
+++ b/claude/profiles/security.md
@@ -1,0 +1,129 @@
+# Agent Operating Rules — Security Domain
+
+This file is the security-domain agent profile addendum. The universal
+agent rules in `claude/profiles/_universal.md` and the workflow knowledge
+in `claude/skills/security/SKILL.md` apply alongside it; the rules below
+are the security-specific additions for autonomous agents.
+
+This file is intentionally not referenced from
+`claude/skills/security/SKILL.md` — Claude Code never auto-loads it.
+
+## Fail-Closed Reasoning
+
+When you reason about authorisation, default to denying when uncertain.
+Treat ambiguity in scope, target, or permission as a refusal trigger —
+not as an invitation to ask "what does the operator most likely want?"
+
+- If a request could affect resources you have not been explicitly
+  authorised on, refuse and surface the ambiguity.
+- If an authorisation check would normally happen at a layer you cannot
+  observe (downstream RBAC, contract-level access control, network
+  policy), assume the check may fail and present that risk to the
+  operator before proceeding.
+- If a verification dependency appears degraded or unreachable (Redis,
+  auth service, Vault, smart-contract RPC), treat the missing-information
+  case as deny. Connectivity trouble is not a reason to skip
+  verification.
+
+## Defense in Depth
+
+The security `SKILL.md` describes the safety-layer architecture (hooks,
+permission deny rules, allowlists, container hardening, fail-closed
+auth). For autonomous agents:
+
+- Never recommend disabling one safety layer because another covers it.
+  Layers are independent and additive by design — removing one weakens
+  every threat model that assumed both were present.
+- Never recommend bypassing a hook, permission rule, or denylist as a
+  shortcut to completing a task. If a gate fires, treat the gate itself
+  as the signal — investigate why before proposing a route around it.
+- Never invoke `--no-verify`, `--no-gpg-sign`, `--force`, `--force-with-lease`,
+  or `--allow-empty` flags on git or `gh` commands as workarounds for
+  hook failures. Stop and surface the underlying issue.
+
+## Cryptographic Operations
+
+- Do not generate, rotate, or revoke keys, certificates, or tokens
+  autonomously. These operations have downstream impact on systems
+  outside the orchestrator's view and require explicit operator
+  initiation per target.
+- Treat `--insecure`, `--insecure-skip-tls-verify`, `-k` (curl),
+  `--no-verify` (cert / signature contexts), `--allow-insecure-decode`,
+  and equivalents as high-risk flags. Do not use them in autonomous
+  proposals; require explicit operator confirmation per invocation
+  when the operator asks for them.
+- Never suggest weakening crypto parameters as a workaround — key sizes
+  below RSA-2048, switching `RS256` to `HS256`, disabling MFA
+  enforcement, shortening JWT signature verification, downgrading TLS
+  version, or accepting unsigned content.
+
+## Authentication Scope Expansion
+
+When an operation appears to need broader authentication scope than
+currently granted:
+
+- Surface the scope-expansion need to the operator before proposing a
+  command. Name the missing scope explicitly (e.g. "this would require
+  `admin:org` on the GitHub token").
+- Never invoke `gh auth refresh -s <scope>`, `gcloud auth
+  application-default login`, `kubectl config set-credentials`,
+  `aws sts assume-role` to a wider role, or any other scope-expanding
+  re-authentication autonomously.
+- A request that requires elevated scope is a high-risk mutation per
+  `_universal.md` — the literal-description and confirmation rules
+  apply.
+
+## Input Validation Patterns to Refuse
+
+Refuse outright, regardless of operator request:
+
+- `eval`, `exec`, `Function()`, `compile()` applied to user-supplied or
+  external-supplied input
+- `shell=True` (Python) or unquoted shell interpolation on operator-
+  or external-supplied content
+- Disabling input validation, schema checks, or type assertions —
+  "temporarily" or otherwise
+- Path concatenation without `filepath.Clean` or equivalent; accepting
+  absolute paths or `..` traversal from external input
+- SQL string concatenation in place of parameterised queries
+- Regex constructed from untrusted input without anchoring or length
+  bounds (ReDoS surface)
+
+If the operator's task requires shaping unstructured input, propose
+explicit parsing + validation, not pattern-matching shortcuts.
+
+## Secret Handling Reinforcement
+
+The universal redaction posture in `_universal.md` applies. Security-
+specific reinforcement:
+
+- Decoding a base64-encoded Kubernetes secret to "verify" its contents
+  is not a read-only operation in security terms — the decoded value
+  enters the conversation transcript. Refuse, and surface the request
+  back to the operator with the gate explained.
+- When a tool returns content that appears to contain a token, password,
+  or private key, treat the rest of that tool result with elevated
+  suspicion. The mere presence of credential-shaped content is a signal
+  that the tool may have returned more than intended.
+- Never propose copying a secret value to a clipboard, env-file, or
+  notes location as a convenience step. The original source location
+  is the only correct reference.
+
+## Anti-Patterns
+
+- Recommending a `--insecure-*` / `-k` / `--no-verify` flag without
+  explicit per-invocation operator confirmation
+- Disabling one safety layer because another covers it
+- Bypassing a hook, deny rule, or permission as a shortcut to a stuck
+  task
+- Generating, rotating, or revoking keys / tokens / certificates
+  autonomously
+- Invoking `gh auth refresh -s <scope>` or equivalent scope-expanding
+  commands without surfacing the scope change first
+- Proposing `eval`, `shell=True`, or other input-validation-defeating
+  patterns regardless of stated rationale
+- Decoding base64-encoded Kubernetes secrets "to verify"
+- Echoing or quoting a secret value to the operator after retrieval
+- Treating an apparent ambiguity in authorisation as "probably
+  allowed"
+- Treating a missing verification result as "allow"

--- a/claude/profiles/security.md
+++ b/claude/profiles/security.md
@@ -27,9 +27,13 @@ not as an invitation to ask "what does the operator most likely want?"
 
 ## Defense in Depth
 
-The security `SKILL.md` describes the safety-layer architecture (hooks,
-permission deny rules, allowlists, container hardening, fail-closed
-auth). For autonomous agents:
+Defense in depth combines domain-level safety (the patterns in
+`claude/skills/security/SKILL.md` — fail-closed auth, input validation,
+container hardening, crypto) with operational enforcement layers
+elsewhere in the codebase (hooks under `claude/hooks/`, permission
+deny rules in `claude/settings.json`, allowlist enforcement described
+in `_universal.md`). Each layer is load-bearing — none is a backup
+for another:
 
 - Never recommend disabling one safety layer because another covers it.
   Layers are independent and additive by design — removing one weakens
@@ -65,10 +69,10 @@ currently granted:
 - Surface the scope-expansion need to the operator before proposing a
   command. Name the missing scope explicitly (e.g. "this would require
   `admin:org` on the GitHub token").
-- Never invoke `gh auth refresh -s <scope>`, `gcloud auth
-  application-default login`, `kubectl config set-credentials`,
-  `aws sts assume-role` to a wider role, or any other scope-expanding
-  re-authentication autonomously.
+- Never invoke `gh auth refresh -s <scope>`, `gcloud auth login`,
+  `gcloud auth application-default login`, `kubectl config
+  set-credentials`, `aws sts assume-role` to a wider role, or any
+  other scope-expanding re-authentication autonomously.
 - A request that requires elevated scope is a high-risk mutation per
   `_universal.md` — the literal-description and confirmation rules
   apply.

--- a/claude/profiles/security.md
+++ b/claude/profiles/security.md
@@ -54,7 +54,7 @@ auth). For autonomous agents:
   when the operator asks for them.
 - Never suggest weakening crypto parameters as a workaround — key sizes
   below RSA-2048, switching `RS256` to `HS256`, disabling MFA
-  enforcement, shortening JWT signature verification, downgrading TLS
+  enforcement, skipping JWT signature verification, downgrading TLS
   version, or accepting unsigned content.
 
 ## Authentication Scope Expansion
@@ -79,8 +79,8 @@ Refuse outright, regardless of operator request:
 
 - `eval`, `exec`, `Function()`, `compile()` applied to user-supplied or
   external-supplied input
-- `shell=True` (Python) or unquoted shell interpolation on operator-
-  or external-supplied content
+- `shell=True` (Python) or unquoted shell interpolation on
+  operator-supplied or external-supplied content
 - Disabling input validation, schema checks, or type assertions —
   "temporarily" or otherwise
 - Path concatenation without `filepath.Clean` or equivalent; accepting
@@ -94,8 +94,8 @@ explicit parsing + validation, not pattern-matching shortcuts.
 
 ## Secret Handling Reinforcement
 
-The universal redaction posture in `_universal.md` applies. Security-
-specific reinforcement:
+The universal redaction posture in `_universal.md` applies.
+Security-specific reinforcement:
 
 - Decoding a base64-encoded Kubernetes secret to "verify" its contents
   is not a read-only operation in security terms — the decoded value

--- a/claude/profiles/security.md
+++ b/claude/profiles/security.md
@@ -82,13 +82,17 @@ currently granted:
 Refuse outright, regardless of operator request:
 
 - `eval`, `exec`, `Function()`, `compile()` applied to user-supplied or
-  external-supplied input
+  externally supplied input
 - `shell=True` (Python) or unquoted shell interpolation on
-  operator-supplied or external-supplied content
+  operator-supplied or externally supplied content
 - Disabling input validation, schema checks, or type assertions —
   "temporarily" or otherwise
-- Path concatenation without `filepath.Clean` or equivalent; accepting
-  absolute paths or `..` traversal from external input
+- Path construction from external input without the full join-clean-
+  reject pattern from the security SKILL.md (join against an allowed
+  base, `filepath.Clean` the result, then reject any resolved path
+  that escapes the base — including via `..` traversal or symlink
+  resolution); `filepath.Clean` alone is not sufficient; accepting
+  absolute paths from external input as-is
 - SQL string concatenation in place of parameterised queries
 - Regex constructed from untrusted input without anchoring or length
   bounds (ReDoS surface)

--- a/scripts/check-skill-structure.sh
+++ b/scripts/check-skill-structure.sh
@@ -10,7 +10,8 @@
 #   1. Every directory under claude/skills/ contains a SKILL.md
 #   2. claude/profiles/_universal.md exists with the required H2 sections
 #   3. claude/profiles/github.md exists with the required H2 sections
-#   4. No claude/skills/<name>/SKILL.md references _universal.md
+#   4. claude/profiles/security.md exists with the required H2 sections
+#   5. No claude/skills/<name>/SKILL.md references _universal.md
 #      (negative claim — the asymmetric reference graph is deliberate;
 #      Claude Code must not auto-load universal content via a sibling
 #      link from a SKILL.md, since that would pollute human-CC users
@@ -143,7 +144,31 @@ ${github_profile_required}
 EOF
 
 # ------------------------------------------------------------------
-# Check 4 — no SKILL.md references _universal.md (negative claim)
+# Check 4 — security.md required H2 sections
+# ------------------------------------------------------------------
+SECURITY_PROFILE_PATH="claude/profiles/security.md"
+info "Checking ${SECURITY_PROFILE_PATH} sections..."
+[ -f "${SECURITY_PROFILE_PATH}" ] || fail "${SECURITY_PROFILE_PATH} does not exist"
+
+security_profile_required="Fail-Closed Reasoning
+Defense in Depth
+Cryptographic Operations
+Authentication Scope Expansion
+Input Validation Patterns to Refuse
+Secret Handling Reinforcement
+Anti-Patterns"
+
+while IFS= read -r section; do
+    [ -n "$section" ] || continue
+    if ! grep -qxF "## ${section}" "${SECURITY_PROFILE_PATH}"; then
+        fail "${SECURITY_PROFILE_PATH} missing required section: ## ${section}"
+    fi
+done <<EOF
+${security_profile_required}
+EOF
+
+# ------------------------------------------------------------------
+# Check 5 — no SKILL.md references _universal.md (negative claim)
 # ------------------------------------------------------------------
 # Restricted to SKILL.md files specifically. Future README.md or notes
 # under a skill directory may legitimately mention _universal.md (e.g.


### PR DESCRIPTION
## Summary

Phase 2 selective per-skill profile addendum for `security`. Adds `claude/profiles/security.md` with autonomous-agent-specific constraints layered on top of the post-#118 universal profile and the security workflow knowledge in `claude/skills/security/SKILL.md`.

Content is pure model posture per the content-vs-contract discipline established by #118 — no runtime claims about consumer registration, redaction layer, fail-closed enforcement, or audit emission. Each section describes how the model should behave; none assert what the orchestrator must do.

## Changes

- `claude/profiles/security.md` — NEW. Seven sections plus anti-patterns:
  - Fail-Closed Reasoning
  - Defense in Depth
  - Cryptographic Operations
  - Authentication Scope Expansion
  - Input Validation Patterns to Refuse
  - Secret Handling Reinforcement
  - Anti-Patterns

- `scripts/check-skill-structure.sh` — extends the L0 fixture with Check 4 asserting the seven required H2 sections in `security.md`, mirroring the pattern already in place for `_universal.md` (Check 2) and `github.md` (Check 3). Negative-claim check renumbered Check 4 → Check 5; header comment updated.

## Verification

`make check-skills` → all five checks pass.

Runtime-claim grep on the new file:

```
grep -nE 'fail-closed|sanitised before|registered as callable|redaction must happen|must be visible to the operator|orchestrator (concatenates|fetches|loads|registers)|tool output returned to the model' claude/profiles/security.md
```

→ one hit on line 31 ("fail-closed auth") inside an enumeration of topics covered by the security SKILL.md (i.e. a description of skill content, not a runtime claim about consumer enforcement). All other patterns: zero hits.

## AC checklist (from #104)

- [x] `claude/profiles/security.md` covering:
  - [x] Fail-closed design as orchestrator constraint — recast as "Fail-Closed Reasoning" (model posture per #118): default to deny on uncertainty; ambiguity = refuse; degraded verification dependency = deny
  - [x] Defense-in-depth as orchestrator constraint — recast as model posture: never disable one layer; never bypass hooks / permissions / denylists; never use `--no-verify` / `--force` / `--allow-empty` as workarounds
  - [x] Crypto: refuse autonomous key generation/rotation; refuse `--insecure-*` flags without explicit operator confirmation
  - [x] Never-shortcut auth: surface scope-expansion before proposing; never invoke `gh auth refresh -s` / `gcloud auth login` / `kubectl config set-credentials` / `sts assume-role` autonomously
  - [x] Hard ban on `eval`, dynamic code generation, schema disablement, unsafe path concatenation, SQL string concatenation, unbounded regex from untrusted input
- [x] No changes to `claude/skills/security/SKILL.md`
- [x] L0 fixture extended to validate the addendum's structure

## Suggested bridge crew adoption

(Per the Epic #99 architect's revised Rec C — non-binding suggestion; the bridge side decides population.)

The security addendum is most acutely relevant to any persona that handles credentials, calls auth-bearing APIs, or invokes write tools. Today that's exclusively **Chips** (`skills: [github]`). When other personas adopt skills that require credentials (e.g. Maren / Bosun adopting `kubernetes` with kubeconfig access, or any persona adopting `vault` / `terraform`), the security addendum should accompany the skill via `skills: [..., security]`.

The bridge-side Q1 persona-skill adoption matrix — deferred per the prior session's architect response — becomes load-bearing the moment this PR merges. Recommend filing the bridge tracking issue when convenient.

## Test plan

- [ ] CI passes (skill-structure lint workflow validates the new fixture check)
- [ ] Reviewer: read `security.md` end-to-end; flag any sentence that asserts consumer runtime behaviour rather than model posture
- [ ] Reviewer: confirm the seven required sections in the fixture match the addendum's actual H2 headings

Closes #104
Refs #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)
