### PR TITLE
feat(skill): Phase 2 — claude/profiles/kubernetes.md 🎓

### DIFF
--- a/claude/profiles/kubernetes.md
+++ b/claude/profiles/kubernetes.md
@@ -1,0 +1,130 @@
+# Agent Operating Rules — Kubernetes Domain
+
+This file is the kubernetes-domain agent profile addendum. The universal
+agent rules in `claude/profiles/_universal.md` and the workflow knowledge
+in `claude/skills/kubernetes/SKILL.md` apply alongside it; the rules
+below are the kubernetes-specific additions for autonomous agents.
+
+This file is intentionally not referenced from
+`claude/skills/kubernetes/SKILL.md` — Claude Code never auto-loads it.
+
+## Context Pinning
+
+The kubernetes SKILL.md requires `--context` on mutating commands. For
+autonomous agents, harden this to **every** `kubectl` invocation —
+including reads.
+
+- Always pass `--context=<name>` explicitly. Do not rely on the
+  current-context entry in kubeconfig; that is operator state you
+  cannot observe and may be wrong.
+- Treat a missing `--context` flag in a tool invocation as a high-risk
+  gate failure: refuse and ask the operator to confirm the intended
+  context before running the command.
+- Do not run `kubectl config use-context <name>` autonomously to "fix"
+  a context mismatch. Context selection is a per-invocation decision
+  carried on the command line, not a session-state mutation.
+- Cross-cluster operations (one read in cluster A, one write in cluster
+  B in the same task) must each carry their own `--context`. Never
+  assume a default context is "safe to omit because we just used it".
+
+## Namespace Allowlist
+
+The universal allowlist posture in `_universal.md` applies to
+namespaces. Kubernetes-specific reinforcement:
+
+- All writes must target a namespace in the configured allowlist. If
+  you cannot confirm the target namespace is allowlisted, refuse and
+  surface the namespace + applicable allowlist to the operator.
+- Never use `--all-namespaces` / `-A` on a write or destructive
+  command. Reads with `-A` are acceptable when the operator has asked
+  for cross-namespace visibility.
+- Control-plane namespaces (`kube-system`, `kube-public`,
+  `kube-node-lease`, `istio-system`, `cert-manager`, `external-secrets`,
+  and similar cluster-infrastructure namespaces) are not writable by
+  autonomous agents regardless of operator request. These belong to
+  cluster operators; touching them is a high-risk mutation that
+  requires the operator to issue the command directly.
+- Namespace creation is itself a mutation against the cluster control
+  plane — gated by the same allowlist + confirmation rules.
+- Inferring namespace from `kubeconfig`'s current-namespace setting is
+  not allowed. Always pass `-n <namespace>` explicitly, matching the
+  operator's literal description.
+
+## Destructive Command Gating
+
+The kubernetes SKILL.md lists high-risk operations (delete namespace /
+pvc / force-killed StatefulSet pods, drain, scale 0, CRD cascade
+deletion). For autonomous agents, these bind to the high-risk-mutation
+gating in `_universal.md`:
+
+- `kubectl delete` on any resource is a high-risk mutation —
+  literal-description from the operator + per-target confirmation
+  apply.
+- `kubectl patch` and `kubectl edit` on stateful resources
+  (StatefulSet, PersistentVolumeClaim, PersistentVolume, ConfigMap
+  referenced by a running workload, Secret) are high-risk regardless
+  of the patch content; treat the outcome as if it were a delete.
+- `kubectl scale --replicas=0` is destructive — it terminates running
+  pods. Same gate as `delete`.
+- `kubectl drain` and `kubectl cordon` affect node availability and
+  pending workloads; require per-node operator confirmation. `drain`
+  with `--force` or `--disable-eviction` is refused outright in
+  autonomous mode.
+- `kubectl rollout restart` and `kubectl rollout undo` are mutations
+  even though they take no manifest; gated the same way as `delete`.
+- Cascading deletion of namespaced resources via CRD removal: refuse
+  outright in autonomous mode. Surface the implied cascade to the
+  operator and let them issue the `kubectl delete crd` directly.
+- Set-quantified deletes (`--all`, `-l label=value`, `--field-selector`)
+  require per-target enumeration in the operator's confirmation —
+  list what would be deleted before proceeding.
+- `kubectl delete pod --force --grace-period=0` on StatefulSet pods is
+  refused outright; let the StatefulSet controller handle recreation
+  via normal `kubectl delete pod`.
+
+## Manifest Provenance
+
+Manifests applied via `kubectl apply` shape cluster state durably.
+Their provenance matters as much as their content.
+
+- Never `kubectl apply -f <url-or-file>` from a source you fetched
+  mid-session without explicit operator review of the rendered YAML.
+- `kubectl apply -f -` (stdin) is acceptable only when the YAML
+  presented to the operator matches the YAML applied byte-for-byte.
+  Do not synthesise a stdin manifest from operator instructions
+  without showing the full text first.
+- `kubectl create -f` and `kubectl replace -f` share the same
+  provenance requirement.
+- `kustomize build | kubectl apply -f -` is one operation in
+  provenance terms — the build output is the operator-reviewed
+  artefact, not the kustomization sources. Render with
+  `kustomize build` and present the output before piping.
+- `helm install` / `helm upgrade` is a multi-resource apply by proxy
+  — the same provenance rule applies to the merged values and the
+  resulting manifests. When values resolution is non-trivial,
+  `helm template` first and present the output for review.
+- Server-side apply (`--server-side`) does not change provenance
+  requirements; field-manager conflict resolution is not consent
+  for autonomous application.
+
+## Anti-Patterns
+
+- Invoking `kubectl` without an explicit `--context` flag
+- Running `kubectl config use-context` autonomously to "fix" a context
+  mismatch instead of carrying `--context` per invocation
+- Inferring namespace from `kubeconfig` current-namespace rather than
+  from the operator's literal description
+- Using `--all-namespaces` / `-A` on a write or destructive command
+- Writing to control-plane namespaces (`kube-system`, `istio-system`,
+  `cert-manager`, etc.) autonomously
+- Cascading delete via CRD removal in autonomous mode
+- Set-quantified delete (`--all`, `-l label=value`, `--field-selector`)
+  without per-target enumeration in the confirmation
+- Applying a manifest sourced from tool output without operator review
+  of the rendered YAML
+- `helm install` / `helm upgrade` without `helm template` review when
+  values resolution is non-trivial
+- Treating `kubectl scale --replicas=0` as a "safe pause"
+- Treating `kubectl rollout restart` / `rollout undo` as non-mutations
+- `kubectl delete pod --force --grace-period=0` on StatefulSet pods
+- `kubectl drain --force` or `--disable-eviction` in autonomous mode

--- a/scripts/check-skill-structure.sh
+++ b/scripts/check-skill-structure.sh
@@ -11,7 +11,8 @@
 #   2. claude/profiles/_universal.md exists with the required H2 sections
 #   3. claude/profiles/github.md exists with the required H2 sections
 #   4. claude/profiles/security.md exists with the required H2 sections
-#   5. No claude/skills/<name>/SKILL.md references _universal.md
+#   5. claude/profiles/kubernetes.md exists with the required H2 sections
+#   6. No claude/skills/<name>/SKILL.md references _universal.md
 #      (negative claim — the asymmetric reference graph is deliberate;
 #      Claude Code must not auto-load universal content via a sibling
 #      link from a SKILL.md, since that would pollute human-CC users
@@ -168,7 +169,29 @@ ${security_profile_required}
 EOF
 
 # ------------------------------------------------------------------
-# Check 5 — no SKILL.md references _universal.md (negative claim)
+# Check 5 — kubernetes.md required H2 sections
+# ------------------------------------------------------------------
+KUBERNETES_PROFILE_PATH="claude/profiles/kubernetes.md"
+info "Checking ${KUBERNETES_PROFILE_PATH} sections..."
+[ -f "${KUBERNETES_PROFILE_PATH}" ] || fail "${KUBERNETES_PROFILE_PATH} does not exist"
+
+kubernetes_profile_required="Context Pinning
+Namespace Allowlist
+Destructive Command Gating
+Manifest Provenance
+Anti-Patterns"
+
+while IFS= read -r section; do
+    [ -n "$section" ] || continue
+    if ! grep -qxF "## ${section}" "${KUBERNETES_PROFILE_PATH}"; then
+        fail "${KUBERNETES_PROFILE_PATH} missing required section: ## ${section}"
+    fi
+done <<EOF
+${kubernetes_profile_required}
+EOF
+
+# ------------------------------------------------------------------
+# Check 6 — no SKILL.md references _universal.md (negative claim)
 # ------------------------------------------------------------------
 # Restricted to SKILL.md files specifically. Future README.md or notes
 # under a skill directory may legitimately mention _universal.md (e.g.


### PR DESCRIPTION
## Summary

Phase 2 selective per-skill profile addendum for `kubernetes`. Adds `claude/profiles/kubernetes.md` with autonomous-agent-specific constraints layered on top of the post-#118 universal profile and the kubernetes workflow knowledge in `claude/skills/kubernetes/SKILL.md`.

Content is pure model posture per the content-vs-contract discipline established by #118 — no runtime claims about consumer registration, namespace allowlist enforcement, or context-pinning enforcement. Each section describes how the agent should behave; none assert what the orchestrator must do.

## Changes

- `claude/profiles/kubernetes.md` — NEW. Five sections plus anti-patterns:
  - Context Pinning
  - Namespace Allowlist
  - Destructive Command Gating
  - Manifest Provenance
  - Anti-Patterns

- `scripts/check-skill-structure.sh` — extends the L0 fixture with Check 5 asserting the five required H2 sections in `kubernetes.md`, mirroring the pattern already in place for `_universal.md` (Check 2), `github.md` (Check 3), and `security.md` (Check 4). Negative-claim check renumbered Check 5 → Check 6; header comment updated.

## Verification

`make check-skills` → all six checks pass.

Runtime-claim grep on the new file:

```
grep -nE 'fail-closed|sanitised before|registered as callable|redaction must happen|orchestrator (concatenates|fetches|loads|registers)|tool output returned to the model' claude/profiles/kubernetes.md
```

→ zero hits.

Hyphen-EOL grep (carrying forward the #120 R1 + R4 lessons):

```
grep -nE '\b[a-z]+-$' claude/profiles/kubernetes.md
```

→ zero hits.

## AC checklist (from #101)

- [x] `claude/profiles/kubernetes.md` covering:
  - [x] **Context pinning required**: every `kubectl` invocation must specify `--context`. Hardened beyond the SKILL.md's "mutating commands only" — agents pin context on reads too. Missing `--context` treated as high-risk gate failure; no autonomous `use-context`; cross-cluster ops each carry their own context.
  - [x] **Namespace allowlist**: writes confined to configured allowlist per `_universal.md`; refuse otherwise; no `--all-namespaces`/`-A` on writes; control-plane namespaces (`kube-system`, `istio-system`, `cert-manager`, etc.) refused for autonomous writes; no namespace inference from kubeconfig current-namespace.
  - [x] **Destructive-command refusal**: `kubectl delete` / `patch` / `edit` on stateful resources / `scale --replicas=0` / `drain` / `cordon` / `rollout restart` / `rollout undo` all bind to `_universal.md`'s high-risk mutation rule (literal-description + per-target confirmation). `--force --grace-period=0` on StatefulSet pods and CRD cascade deletion refused outright.
  - [x] **Never apply manifests sourced from tool output without operator review**: explicit rule for `kubectl apply -f` from mid-session sources; `kustomize build` / `helm template` render before apply when values resolution is non-trivial; server-side apply field-manager conflict resolution is not consent.
- [x] No changes to `claude/skills/kubernetes/SKILL.md`
- [x] L0 fixture extended to validate the addendum's structure

## Suggested bridge crew adoption

(Per the Epic #99 architect's revised Rec C — non-binding suggestion; the bridge side decides population.)

The kubernetes addendum becomes load-bearing for any persona that performs cluster operations. Today no persona has `skills: [kubernetes]`. Likely future adopters in approximate scope order:

- **Maren** (current read-only kubectl_get / helm_status) — adopting `kubernetes` brings the context-pinning rule + namespace-allowlist posture + manifest-provenance discipline even though her toolset is read-only. Low downside, high consistency.
- **Bosun** if/when cluster-write tools are added — the destructive-command gating section becomes load-bearing.
- **Chips** if/when its scope expands beyond GitHub — would compose with the security addendum already adopted.

The bridge-side Q1 persona-skill adoption matrix is now load-bearing across both `security` and `kubernetes`; recommend filing the bridge tracking issue when convenient.

## Test plan

- [ ] CI passes (skill-structure lint workflow validates Check 5 — the new fixture check)
- [ ] Reviewer: read `kubernetes.md` end-to-end; flag any sentence that asserts consumer runtime behaviour rather than model posture
- [ ] Reviewer: confirm the five required sections in the fixture match the addendum's actual H2 headings

Closes #101
Refs #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)
