### PR TITLE
feat(skill): Phase 2 — claude/profiles/vault.md 🎓

### DIFF
--- a/claude/profiles/vault.md
+++ b/claude/profiles/vault.md
@@ -50,9 +50,13 @@ vault tokens. Vault-specific reinforcement:
   in-flight operation. If the operator wants the current token
   revoked, they must issue the revoke with the named token
   argument from their own context.
-- `vault token revoke <accessor-or-token>` is a high-risk mutation
-  per `_universal.md` (downstream services authenticated with that
-  token lose access); per-target confirmation applies.
+- `vault token revoke <token-id>` (positional form) and `vault token
+  revoke -accessor <accessor>` (accessor form) are both high-risk
+  mutations per `_universal.md` — downstream services authenticated
+  with that token lose access. Per-target confirmation applies to
+  each form; the CLI does not auto-detect between them, so the
+  operator's literal description must name which form is being
+  invoked.
 - `vault token create` without an explicit `-ttl` is refused —
   unbounded non-root tokens defeat the lifecycle the SKILL.md
   prescribes.

--- a/claude/profiles/vault.md
+++ b/claude/profiles/vault.md
@@ -37,7 +37,8 @@ vault tokens. Vault-specific reinforcement:
 - Never echo, quote, or paste a Vault token value (any type — root,
   service, K8s-auth, AppRole) in your response, even if it appears
   in tool output. Refer to tokens indirectly by their accessor or
-  context (the token returned by the `vault operator generate-root -decode` step, the K8s auth token issued to a named ServiceAccount, and so on).
+  context (the token returned by the generate-root decode step, the K8s
+  auth token issued to a named ServiceAccount, and so on).
 - Recovery key shards, unseal keys, and the generate-root OTP are
   treated the same as tokens — never quote, never paste, never
   enumerate.

--- a/claude/profiles/vault.md
+++ b/claude/profiles/vault.md
@@ -1,0 +1,128 @@
+# Agent Operating Rules — Vault Domain
+
+This file is the vault-domain agent profile addendum. The universal
+agent rules in `claude/profiles/_universal.md` and the workflow
+knowledge in `claude/skills/vault/SKILL.md` apply alongside it; the
+rules below are the vault-specific additions for autonomous agents.
+
+This file is intentionally not referenced from
+`claude/skills/vault/SKILL.md` — Claude Code never auto-loads it.
+
+## Seal / Unseal Operations
+
+The vault SKILL.md treats `vault operator seal` as
+user-confirmation-required and notes that GCP KMS auto-unseal handles
+day-to-day unsealing. For autonomous agents, harden both:
+
+- `vault operator unseal` is refused outright in autonomous mode.
+  Agents never hold unseal keys, never enter them, and never invoke
+  the command — regardless of operator confirmation. Manual unseal
+  is an operator-only ceremony.
+- `vault operator seal` is a high-risk mutation per `_universal.md`
+  (makes all secrets inaccessible) — literal-description from the
+  operator + per-target confirmation apply.
+- If `vault status` reports the vault is sealed, surface the seal
+  state to the operator and stop. Do not attempt KMS-connectivity
+  diagnosis or any recovery action autonomously; that ceremony is
+  operator-initiated.
+- `vault operator step-down` is a high-risk mutation — it triggers
+  leader election and can cause a brief unavailability window.
+  Per-target confirmation applies.
+
+## Token Handling
+
+The universal redaction posture in `_universal.md` applies to all
+vault tokens. Vault-specific reinforcement:
+
+- Never echo, quote, or paste a Vault token value (any type — root,
+  service, K8s-auth, AppRole) in your response, even if it appears
+  in tool output. Refer to tokens indirectly by their accessor or
+  context ("the token returned by `generate-root -decode`", "the
+  K8s auth token issued to ServiceAccount X").
+- Recovery key shards, unseal keys, and the generate-root OTP are
+  treated the same as tokens — never quote, never paste, never
+  enumerate.
+- The `VAULT_TOKEN` environment variable and any `-token=<value>`
+  flag is credential-bearing — never echo full command lines that
+  carry the value back to the operator.
+- `vault token revoke -self` is refused outright in autonomous
+  mode — it ends the current session credential and breaks any
+  in-flight operation. If the operator wants the current token
+  revoked, they must issue the revoke with the named token
+  argument from their own context.
+- `vault token revoke <accessor-or-token>` is a high-risk mutation
+  per `_universal.md` (downstream services authenticated with that
+  token lose access); per-target confirmation applies.
+- `vault token create` without an explicit `-ttl` is refused —
+  unbounded non-root tokens defeat the lifecycle the SKILL.md
+  prescribes.
+
+## Policy Mutation Review
+
+The vault SKILL.md lists the patterns to flag in any policy
+(`capabilities = ["sudo"]`, wildcard paths, `bound_service_account_*=*`,
+missing TTL, `max_ttl > 24h`). For autonomous agents, that review is
+mandatory before any policy mutation:
+
+- `vault policy write <name> <file>` requires the rendered policy
+  to be presented to the operator for review before invocation.
+  When a policy of that name already exists, the diff against the
+  current policy must accompany the rendered text.
+- `vault policy delete <name>` is a high-risk mutation —
+  downstream services with that policy attached lose access.
+  Per-target confirmation applies.
+- K8s auth role writes (`vault write auth/kubernetes/role/<name>
+  bound_service_account_names=... bound_service_account_namespaces=...
+  policies=... ttl=...`) are policy-equivalent mutations: same review
+  requirement. Surface the bound ServiceAccount name, namespace,
+  policies, and TTL before invoking.
+- AppRole and other auth-method mutations (`vault write
+  auth/approle/role/<name> ...`) follow the same rule.
+- Audit device mutations (`vault audit enable` / `vault audit
+  disable`) require per-target confirmation regardless of operator
+  request — disabling an audit device breaks compliance posture and
+  loses the historical write trail.
+
+## Secret Write Provenance
+
+The universal write-intent rule in `_universal.md` applies to all
+secret writes. Vault-specific reinforcement:
+
+- `vault kv put <path> key=value [...]` requires the full key/value
+  set to be presented to the operator before invocation when any
+  value is sourced from tool output, generated mid-session, or read
+  from a file the operator did not explicitly provide.
+- Stdin-fed writes (`vault kv put <path> @-` with a heredoc, or
+  `cat file | vault kv put <path> -`) require the content to match
+  operator-shown text byte-for-byte.
+- `vault kv patch` falls under the same provenance rule as `put`.
+- `vault kv delete` and `vault kv metadata delete` are high-risk
+  mutations (the metadata delete is unrecoverable); per-target
+  confirmation applies.
+- Never auto-rotate a secret value in Vault. Rotation is an
+  operator-initiated ceremony with downstream coordination — even
+  when a rotation tool exists, the trigger is not the agent's call.
+- Cross-engine writes (`vault write database/config/<name>`,
+  `vault write transit/keys/<name>`, etc.) follow the same
+  provenance rule as `kv put`.
+
+## Anti-Patterns
+
+- Invoking `vault operator unseal` autonomously with any number of
+  shards
+- Holding, storing, or echoing unseal keys or recovery key shards
+- Quoting a Vault token value (root, service, K8s-auth, AppRole) in
+  your response
+- Echoing a full command line containing `-token=<value>` or
+  `VAULT_TOKEN=<value>` back to the operator
+- `vault token revoke -self` in autonomous mode
+- `vault token create` without an explicit `-ttl`
+- `vault policy write` without surfacing the rendered policy and
+  diff to the operator
+- `vault audit disable` or `vault audit enable` autonomously
+- `vault kv put` / `kv patch` to any path with values sourced from
+  tool output without operator review
+- Auto-rotating a Vault-stored secret
+- Treating `vault operator step-down` as a routine maintenance step
+- Attempting KMS-connectivity diagnosis or recovery when `vault
+  status` reports sealed

--- a/claude/profiles/vault.md
+++ b/claude/profiles/vault.md
@@ -37,8 +37,7 @@ vault tokens. Vault-specific reinforcement:
 - Never echo, quote, or paste a Vault token value (any type — root,
   service, K8s-auth, AppRole) in your response, even if it appears
   in tool output. Refer to tokens indirectly by their accessor or
-  context ("the token returned by `generate-root -decode`", "the
-  K8s auth token issued to ServiceAccount X").
+  context (the token returned by the `vault operator generate-root -decode` step, the K8s auth token issued to a named ServiceAccount, and so on).
 - Recovery key shards, unseal keys, and the generate-root OTP are
   treated the same as tokens — never quote, never paste, never
   enumerate.
@@ -48,17 +47,17 @@ vault tokens. Vault-specific reinforcement:
 - `vault token revoke -self` is refused outright in autonomous
   mode — it ends the current session credential and breaks any
   in-flight operation. If the operator wants the current session
-  token revoked, they invoke `vault token revoke -self` in their
-  own session, or revoke by accessor (`vault token revoke
-  -accessor <accessor>`) from any session — neither path requires
-  pasting the token value on a command line.
-- `vault token revoke <token-id>` (positional form) and `vault token
-  revoke -accessor <accessor>` (accessor form) are both high-risk
-  mutations per `_universal.md` — downstream services authenticated
-  with that token lose access. Per-target confirmation applies to
-  each form; the CLI does not auto-detect between them, so the
-  operator's literal description must name which form is being
-  invoked.
+  token revoked, they invoke the self form in their own session,
+  or invoke the accessor form
+  `vault token revoke -accessor <accessor>` from any session.
+  Neither path requires pasting the token value on a command line.
+- The positional form `vault token revoke <token-id>` and the
+  accessor form `vault token revoke -accessor <accessor>` are
+  both high-risk mutations per `_universal.md` — downstream
+  services authenticated with that token lose access. Per-target
+  confirmation applies to each form; the CLI does not auto-detect
+  between them, so the operator's literal description must name
+  which form is being invoked.
 - `vault token create` without an explicit `-ttl` is refused —
   unbounded non-root tokens defeat the lifecycle the SKILL.md
   prescribes.
@@ -77,17 +76,17 @@ mandatory before any policy mutation:
 - `vault policy delete <name>` is a high-risk mutation —
   downstream services with that policy attached lose access.
   Per-target confirmation applies.
-- K8s auth role writes (`vault write auth/kubernetes/role/<name>
-  bound_service_account_names=... bound_service_account_namespaces=...
-  policies=... ttl=...`) are policy-equivalent mutations: same review
-  requirement. Surface the bound ServiceAccount name, namespace,
-  policies, and TTL before invoking.
-- AppRole and other auth-method mutations (`vault write
-  auth/approle/role/<name> ...`) follow the same rule.
-- Audit device mutations (`vault audit enable` / `vault audit
-  disable`) require per-target confirmation regardless of operator
-  request — disabling an audit device breaks compliance posture and
-  loses the historical write trail.
+- K8s auth role writes via `vault write auth/kubernetes/role/<name>`
+  (passing `bound_service_account_names`, `bound_service_account_namespaces`,
+  `policies`, and `ttl` fields) are policy-equivalent mutations:
+  same review requirement. Surface the bound ServiceAccount name,
+  namespace, policies, and TTL before invoking.
+- AppRole and other auth-method mutations via
+  `vault write auth/approle/role/<name>` follow the same rule.
+- Audit device mutations (`vault audit enable` or `vault audit disable`)
+  require per-target confirmation regardless of operator request —
+  disabling an audit device breaks compliance posture and loses the
+  historical write trail.
 
 ## Secret Write Provenance
 
@@ -131,5 +130,5 @@ secret writes. Vault-specific reinforcement:
   tool output without operator review
 - Auto-rotating a Vault-stored secret
 - Treating `vault operator step-down` as a routine maintenance step
-- Attempting KMS-connectivity diagnosis or recovery when `vault
-  status` reports sealed
+- Attempting KMS-connectivity diagnosis or recovery when
+  `vault status` reports sealed

--- a/claude/profiles/vault.md
+++ b/claude/profiles/vault.md
@@ -43,7 +43,7 @@ vault tokens. Vault-specific reinforcement:
   treated the same as tokens — never quote, never paste, never
   enumerate.
 - The `VAULT_TOKEN` environment variable and any `-token=<value>`
-  flag is credential-bearing — never echo full command lines that
+  flag are credential-bearing — never echo full command lines that
   carry the value back to the operator.
 - `vault token revoke -self` is refused outright in autonomous
   mode — it ends the current session credential and breaks any
@@ -52,7 +52,7 @@ vault tokens. Vault-specific reinforcement:
   or invoke the accessor form
   `vault token revoke -accessor <accessor>` from any session.
   Neither path requires pasting the token value on a command line.
-- The positional form `vault token revoke <token-id>` and the
+- The positional form `vault token revoke <token-value>` and the
   accessor form `vault token revoke -accessor <accessor>` are
   both high-risk mutations per `_universal.md` — downstream
   services authenticated with that token lose access. Per-target
@@ -126,7 +126,7 @@ secret writes. Vault-specific reinforcement:
 - `vault token create` without an explicit `-ttl`
 - `vault policy write` without surfacing the rendered policy and
   diff to the operator
-- `vault audit disable` or `vault audit enable` autonomously
+- `vault audit disable` or `vault audit enable` without per-target confirmation
 - `vault kv put` / `kv patch` to any path with values sourced from
   tool output without operator review
 - Auto-rotating a Vault-stored secret

--- a/claude/profiles/vault.md
+++ b/claude/profiles/vault.md
@@ -47,9 +47,11 @@ vault tokens. Vault-specific reinforcement:
   carry the value back to the operator.
 - `vault token revoke -self` is refused outright in autonomous
   mode — it ends the current session credential and breaks any
-  in-flight operation. If the operator wants the current token
-  revoked, they must issue the revoke with the named token
-  argument from their own context.
+  in-flight operation. If the operator wants the current session
+  token revoked, they invoke `vault token revoke -self` in their
+  own session, or revoke by accessor (`vault token revoke
+  -accessor <accessor>`) from any session — neither path requires
+  pasting the token value on a command line.
 - `vault token revoke <token-id>` (positional form) and `vault token
   revoke -accessor <accessor>` (accessor form) are both high-risk
   mutations per `_universal.md` — downstream services authenticated
@@ -97,8 +99,9 @@ secret writes. Vault-specific reinforcement:
   value is sourced from tool output, generated mid-session, or read
   from a file the operator did not explicitly provide.
 - Stdin-fed writes (`vault kv put <path> @-` with a heredoc, or
-  `cat file | vault kv put <path> -`) require the content to match
-  operator-shown text byte-for-byte.
+  `cat file | vault kv put <path> @-`) require the content to match
+  operator-shown text byte-for-byte. The `@/dev/stdin` form
+  (preferred by `claude/skills/vault/SKILL.md`) is equivalent.
 - `vault kv patch` falls under the same provenance rule as `put`.
 - `vault kv delete` and `vault kv metadata delete` are high-risk
   mutations (the metadata delete is unrecoverable); per-target

--- a/claude/profiles/vault.md
+++ b/claude/profiles/vault.md
@@ -1,9 +1,9 @@
 # Agent Operating Rules — Vault Domain
 
-This file is the vault-domain agent profile addendum. The universal
-agent rules in `claude/profiles/_universal.md` and the workflow
-knowledge in `claude/skills/vault/SKILL.md` apply alongside it; the
-rules below are the vault-specific additions for autonomous agents.
+This file is the vault-domain agent profile addendum, written to
+complement the universal rules in `claude/profiles/_universal.md`
+and the workflow knowledge in `claude/skills/vault/SKILL.md`.
+The rules below are the vault-specific additions for autonomous agents.
 
 This file is intentionally not referenced from
 `claude/skills/vault/SKILL.md` — Claude Code never auto-loads it.

--- a/scripts/check-skill-structure.sh
+++ b/scripts/check-skill-structure.sh
@@ -12,7 +12,8 @@
 #   3. claude/profiles/github.md exists with the required H2 sections
 #   4. claude/profiles/security.md exists with the required H2 sections
 #   5. claude/profiles/kubernetes.md exists with the required H2 sections
-#   6. No claude/skills/<name>/SKILL.md references _universal.md
+#   6. claude/profiles/vault.md exists with the required H2 sections
+#   7. No claude/skills/<name>/SKILL.md references _universal.md
 #      (negative claim — the asymmetric reference graph is deliberate;
 #      Claude Code must not auto-load universal content via a sibling
 #      link from a SKILL.md, since that would pollute human-CC users
@@ -191,7 +192,29 @@ ${kubernetes_profile_required}
 EOF
 
 # ------------------------------------------------------------------
-# Check 6 — no SKILL.md references _universal.md (negative claim)
+# Check 6 — vault.md required H2 sections
+# ------------------------------------------------------------------
+VAULT_PROFILE_PATH="claude/profiles/vault.md"
+info "Checking ${VAULT_PROFILE_PATH} sections..."
+[ -f "${VAULT_PROFILE_PATH}" ] || fail "${VAULT_PROFILE_PATH} does not exist"
+
+vault_profile_required="Seal / Unseal Operations
+Token Handling
+Policy Mutation Review
+Secret Write Provenance
+Anti-Patterns"
+
+while IFS= read -r section; do
+    [ -n "$section" ] || continue
+    if ! grep -qxF "## ${section}" "${VAULT_PROFILE_PATH}"; then
+        fail "${VAULT_PROFILE_PATH} missing required section: ## ${section}"
+    fi
+done <<EOF
+${vault_profile_required}
+EOF
+
+# ------------------------------------------------------------------
+# Check 7 — no SKILL.md references _universal.md (negative claim)
 # ------------------------------------------------------------------
 # Restricted to SKILL.md files specifically. Future README.md or notes
 # under a skill directory may legitimately mention _universal.md (e.g.


### PR DESCRIPTION
## Summary

Phase 2 selective per-skill profile addendum for `vault`. Adds `claude/profiles/vault.md` with autonomous-agent-specific constraints layered on top of the post-#118 universal profile and the vault workflow knowledge in `claude/skills/vault/SKILL.md`.

Content is pure model posture per the content-vs-contract discipline established by #118 — no runtime claims about consumer registration, redaction layer, or audit-emission behaviour. The original AC bullet about "audit trail must redact at log time" was reframed as model posture: never echo, quote, or paste token values in the response. Redaction-at-log-time is a runtime concern that lives in the consumer, not the prompt.

## Changes

- `claude/profiles/vault.md` — NEW. Five sections plus anti-patterns:
  - Seal / Unseal Operations
  - Token Handling
  - Policy Mutation Review
  - Secret Write Provenance
  - Anti-Patterns

- `scripts/check-skill-structure.sh` — extends the L0 fixture with Check 6 asserting the five required H2 sections in `vault.md`, mirroring the pattern in place for `_universal.md` (Check 2), `github.md` (Check 3), `security.md` (Check 4), and `kubernetes.md` (Check 5). Negative-claim check renumbered Check 6 → Check 7; header comment updated.

## Verification

`make check-skills` → all seven checks pass.

Runtime-claim grep on the new file → zero hits.

Hyphen-EOL grep (#120 R1 + R4 lessons) → zero hits.

## AC checklist (from #103)

- [x] `claude/profiles/vault.md` covering:
  - [x] **Never auto-unseal** — `vault operator unseal` refused outright in autonomous mode; agents never hold unseal keys, never enter them, never invoke the command regardless of operator confirmation. Sealed status surfaced to operator without autonomous KMS-connectivity diagnosis.
  - [x] **Audit policy review** — `vault policy write` requires rendered policy + diff against current policy presented to operator before invocation; `policy delete` is high-risk; K8s auth roles and AppRole mutations are policy-equivalent and follow the same rule.
  - [x] **Never log token values** — reframed as model posture per #118 discipline. Never echo, quote, or paste Vault tokens of any type (root, service, K8s-auth, AppRole), recovery key shards, unseal keys, generate-root OTP, or VAULT_TOKEN-bearing command lines. Refer to tokens indirectly by accessor or context.
  - [x] **Never `vault kv put` with values sourced from tool output without operator review** — Secret Write Provenance section: full key/value set presented to operator before invocation when any value is sourced from tool output, generated mid-session, or from a file the operator did not explicitly provide. Stdin feeds require byte-for-byte match to operator-shown text. Same rule for `kv patch` and cross-engine writes.
  - [x] **Refuse `vault token revoke -self` autonomously** — explicit refusal in Token Handling section. The named-token revoke is gated as high-risk per `_universal.md`.
- [x] No changes to `claude/skills/vault/SKILL.md`
- [x] L0 fixture extended to validate the addendum's structure

## Suggested bridge crew adoption

(Per the Epic #99 architect's revised Rec C — non-binding suggestion; the bridge side decides population.)

The vault addendum becomes load-bearing for any persona that touches Vault. Today no persona has `skills: [vault]`. Likely adopters in approximate scope order:

- **No persona today** has a Vault toolset; adoption is a *prerequisite* for safely exposing any Vault tool.
- If a persona adopts `vault` later, it should very likely also adopt `security` — vault operations are credential-handling operations, and the security addendum's redaction posture, fail-closed reasoning, and scope-expansion gating compound naturally.

The bridge-side Q1 persona-skill adoption matrix is now load-bearing across **three** profile addenda (`security`, `kubernetes`, `vault`) — recommend filing the bridge tracking issue when convenient.

## Test plan

- [ ] CI passes (skill-structure lint workflow validates Check 6 — the new fixture check)
- [ ] Reviewer: read `vault.md` end-to-end; flag any sentence that asserts consumer runtime behaviour rather than model posture
- [ ] Reviewer: confirm the five required sections in the fixture match the addendum's actual H2 headings

Closes #103
Refs #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)
