### PR TITLE
feat(profiles): add claude/profiles/terraform.md — Phase 2 terraform addendum 🎓

### DIFF
--- a/claude/profiles/terraform.md
+++ b/claude/profiles/terraform.md
@@ -60,7 +60,7 @@ Per-target confirmation applies to every state command.
   `terraform apply -replace=<resource>` as the correct path, with
   per-target confirmation.
 - `terraform untaint` is deprecated — never propose it.
-- State backup (`terraform state pull > backup-<timestamp>.tfstate`)
+- State backup (`terraform state pull > backup-$(date +%Y%m%d-%H%M%S).tfstate`)
   must precede any state mutation in the same operator session. The
   agent does not perform the backup unilaterally — surface the
   requirement to the operator and wait for confirmation before
@@ -80,12 +80,11 @@ workspaces. Terraform-specific reinforcement:
 - `terraform workspace new <name>` is a mutation against the workspace
   namespace — gated by the same allowlist and confirmation rules.
 - `terraform workspace select <name>` is a session-state mutation.
-  Carry the workspace name explicitly per operation rather than
-  relying on ambient session state; do not assume the output of
-  `terraform workspace show` at task-start reflects the intended target.
-- Never infer the target workspace from `terraform workspace show`
-  output alone. Require the operator's explicit description of the
-  intended workspace.
+  Before each plan or apply, run `terraform workspace show` to confirm
+  the current workspace and surface it to the operator. Alternatively,
+  use `TF_WORKSPACE=<name>` to pin the workspace per command without
+  mutating session state. Never assume the workspace selected at
+  task-start persists unchanged to the point of execution.
 
 ## Anti-Patterns
 

--- a/claude/profiles/terraform.md
+++ b/claude/profiles/terraform.md
@@ -1,0 +1,102 @@
+# Agent Operating Rules — Terraform Domain
+
+This file is the terraform-domain agent profile addendum, written to
+complement the universal rules in `claude/profiles/_universal.md`
+and the workflow knowledge in `claude/skills/terraform/SKILL.md`.
+The rules below are the terraform-specific additions for autonomous agents.
+
+This file is intentionally not referenced from
+`claude/skills/terraform/SKILL.md` — Claude Code never auto-loads it.
+
+## Apply Gating
+
+The terraform SKILL.md prohibits `terraform apply -auto-approve` and
+requires plan review before any apply. For autonomous agents, harden both:
+
+- `terraform apply` requires an explicit operator go-ahead per the
+  high-risk mutation gating in `_universal.md` — never invoke it
+  autonomously based on plan output alone.
+- `terraform apply -auto-approve` is refused outright in autonomous
+  mode. No flag or argument bypasses the confirmation requirement.
+- `terraform plan` output must be surfaced verbatim to the operator
+  before any apply consideration. Do not summarise or paraphrase —
+  the operator reviews the literal plan text.
+- If applying from a saved plan file (`terraform apply tfplan`),
+  confirm the plan file was generated in the current session before
+  surfacing it for operator review.
+
+## Destroy Refusal
+
+- `terraform destroy` is refused outright in autonomous mode
+  regardless of operator confirmation. Unlike other high-risk
+  mutations, no per-target confirmation unlocks it — if the operator
+  needs a destroy, they invoke it directly.
+- `terraform destroy -target=<resource>` is refused on the same basis;
+  the `-target` flag does not change the risk profile.
+- `terraform plan -destroy -out=<plan>` is refused — it produces a
+  saved plan whose only downstream use is a destroy apply. Running
+  `terraform plan -destroy` without `-out` to surface the destroy scope
+  for operator review is acceptable.
+
+## State Mutation Gating
+
+State operations are high-risk mutations per `_universal.md` — state
+divergence can produce destructive plan output on the next run.
+Per-target confirmation applies to every state command.
+
+- `terraform state rm` — per-target confirmation required. Before
+  invoking, surface the resource address and confirm the operator
+  understands the cloud resource will NOT be destroyed, only removed
+  from Terraform management.
+- `terraform state mv` — per-target confirmation required. Surface
+  source and destination addresses before invoking.
+- `terraform import` — per-target confirmation required. The `.tf`
+  resource block must exist before import; surface the resource address
+  and cloud ID to the operator before invoking.
+- `terraform taint` is deprecated — never propose it. Surface
+  `terraform apply -replace=<resource>` as the correct path, with
+  per-target confirmation.
+- `terraform untaint` is deprecated — never propose it.
+- State backup (`terraform state pull > backup-<timestamp>.tfstate`)
+  must precede any state mutation in the same operator session. The
+  agent does not perform the backup unilaterally — surface the
+  requirement to the operator and wait for confirmation before
+  proceeding to the mutation.
+- `terraform force-unlock <lock-id>` is a high-risk state operation.
+  Per-target confirmation applies; never invoke unless the operator has
+  explicitly confirmed no other operation is in flight.
+
+## Workspace Allowlist
+
+The universal allowlist posture in `_universal.md` applies to
+workspaces. Terraform-specific reinforcement:
+
+- All operations must target a workspace in the configured allowlist.
+  If you cannot confirm the target workspace is allowlisted, refuse and
+  surface the workspace name and applicable allowlist to the operator.
+- `terraform workspace new <name>` is a mutation against the workspace
+  namespace — gated by the same allowlist and confirmation rules.
+- `terraform workspace select <name>` is a session-state mutation.
+  Carry the workspace name explicitly per operation rather than
+  relying on ambient session state; do not assume the output of
+  `terraform workspace show` at task-start reflects the intended target.
+- Never infer the target workspace from `terraform workspace show`
+  output alone. Require the operator's explicit description of the
+  intended workspace.
+
+## Anti-Patterns
+
+- `terraform apply -auto-approve` in any context
+- `terraform apply` without surfacing plan output verbatim to the operator
+- `terraform apply` without explicit operator go-ahead
+- `terraform destroy` in autonomous mode (any form — full or targeted)
+- `terraform plan -destroy -out=<plan>` (produces a destroy-apply artefact)
+- `terraform state rm`, `terraform state mv`, or `terraform import`
+  without per-target operator confirmation
+- `terraform force-unlock` without operator confirmation of no
+  concurrent operations
+- Proposing `terraform taint` or `terraform untaint` (deprecated)
+- Performing the state backup step unilaterally, or skipping it
+- Inferring the target workspace from ambient session state rather than
+  the operator's explicit description
+- Operating on a workspace outside the configured allowlist

--- a/claude/profiles/terraform.md
+++ b/claude/profiles/terraform.md
@@ -65,7 +65,7 @@ Per-target confirmation applies to every state command.
   agent does not perform the backup unilaterally — surface the
   requirement to the operator and wait for confirmation before
   proceeding to the mutation.
-- `terraform force-unlock <lock-id>` is a high-risk state operation.
+- `terraform force-unlock LOCK_ID` is a high-risk state operation.
   Per-target confirmation applies; never invoke unless the operator has
   explicitly confirmed no other operation is in flight.
 
@@ -77,13 +77,13 @@ workspaces. Terraform-specific reinforcement:
 - All operations must target a workspace in the configured allowlist.
   If you cannot confirm the target workspace is allowlisted, refuse and
   surface the workspace name and applicable allowlist to the operator.
-- `terraform workspace new <name>` is a mutation against the workspace
-  namespace — gated by the same allowlist and confirmation rules.
-- `terraform workspace select <name>` is a session-state mutation.
+- `terraform workspace new WORKSPACE_NAME` is a mutation against the
+  workspace namespace — gated by the same allowlist and confirmation rules.
+- `terraform workspace select WORKSPACE_NAME` is a session-state mutation.
   Before each plan or apply, run `terraform workspace show` to confirm
   the current workspace and surface it to the operator. Alternatively,
-  use `TF_WORKSPACE=<name>` to pin the workspace per command without
-  mutating session state. Never assume the workspace selected at
+  use `TF_WORKSPACE=WORKSPACE_NAME` to pin the workspace per command
+  without mutating session state. Never assume the workspace selected at
   task-start persists unchanged to the point of execution.
 
 ## Anti-Patterns

--- a/claude/profiles/terraform.md
+++ b/claude/profiles/terraform.md
@@ -18,9 +18,12 @@ requires plan review before any apply. For autonomous agents, harden both:
   autonomously based on plan output alone.
 - `terraform apply -auto-approve` is refused outright in autonomous
   mode. No flag or argument bypasses the confirmation requirement.
-- `terraform plan` output must be surfaced verbatim to the operator
-  before any apply consideration. Do not summarise or paraphrase —
-  the operator reviews the literal plan text.
+- `terraform plan` output must be reviewed by the operator before any
+  apply consideration. Present the plan output for review, applying
+  standard redaction for any secret values per `_universal.md`. If the
+  plan contains sensitive outputs, instruct the operator to review the
+  full output directly in their terminal rather than reproducing the
+  values in the response.
 - If applying from a saved plan file (`terraform apply tfplan`),
   confirm the plan file was generated in the current session before
   surfacing it for operator review.
@@ -87,7 +90,7 @@ workspaces. Terraform-specific reinforcement:
 ## Anti-Patterns
 
 - `terraform apply -auto-approve` in any context
-- `terraform apply` without surfacing plan output verbatim to the operator
+- `terraform apply` without the operator reviewing the plan output
 - `terraform apply` without explicit operator go-ahead
 - `terraform destroy` in autonomous mode (any form — full or targeted)
 - `terraform plan -destroy -out=<plan>` (produces a destroy-apply artefact)

--- a/claude/profiles/terraform.md
+++ b/claude/profiles/terraform.md
@@ -34,9 +34,9 @@ requires plan review before any apply. For autonomous agents, harden both:
   regardless of operator confirmation. Unlike other high-risk
   mutations, no per-target confirmation unlocks it — if the operator
   needs a destroy, they invoke it directly.
-- `terraform destroy -target=<resource>` is refused on the same basis;
+- `terraform destroy -target=RESOURCE_ADDR` is refused on the same basis;
   the `-target` flag does not change the risk profile.
-- `terraform plan -destroy -out=<plan>` is refused — it produces a
+- `terraform plan -destroy -out=PLAN_PATH` is refused — it produces a
   saved plan whose only downstream use is a destroy apply. Running
   `terraform plan -destroy` without `-out` to surface the destroy scope
   for operator review is acceptable.
@@ -57,7 +57,7 @@ Per-target confirmation applies to every state command.
   resource block must exist before import; surface the resource address
   and cloud ID to the operator before invoking.
 - `terraform taint` is deprecated — never propose it. Surface
-  `terraform apply -replace=<resource>` as the correct path, with
+  `terraform apply -replace=RESOURCE_ADDR` as the correct path, with
   per-target confirmation.
 - `terraform untaint` is deprecated — never propose it.
 - State backup (`terraform state pull > backup-$(date +%Y%m%d-%H%M%S).tfstate`)
@@ -92,7 +92,7 @@ workspaces. Terraform-specific reinforcement:
 - `terraform apply` without the operator reviewing the plan output
 - `terraform apply` without explicit operator go-ahead
 - `terraform destroy` in autonomous mode (any form — full or targeted)
-- `terraform plan -destroy -out=<plan>` (produces a destroy-apply artefact)
+- `terraform plan -destroy -out=PLAN_PATH` (produces a destroy-apply artefact)
 - `terraform state rm`, `terraform state mv`, or `terraform import`
   without per-target operator confirmation
 - `terraform force-unlock` without operator confirmation of no

--- a/scripts/check-skill-structure.sh
+++ b/scripts/check-skill-structure.sh
@@ -13,7 +13,8 @@
 #   4. claude/profiles/security.md exists with the required H2 sections
 #   5. claude/profiles/kubernetes.md exists with the required H2 sections
 #   6. claude/profiles/vault.md exists with the required H2 sections
-#   7. No claude/skills/<name>/SKILL.md references _universal.md
+#   7. claude/profiles/terraform.md exists with the required H2 sections
+#   8. No claude/skills/<name>/SKILL.md references _universal.md
 #      (negative claim — the asymmetric reference graph is deliberate;
 #      Claude Code must not auto-load universal content via a sibling
 #      link from a SKILL.md, since that would pollute human-CC users
@@ -214,7 +215,29 @@ ${vault_profile_required}
 EOF
 
 # ------------------------------------------------------------------
-# Check 7 — no SKILL.md references _universal.md (negative claim)
+# Check 7 — terraform.md required H2 sections
+# ------------------------------------------------------------------
+TERRAFORM_PROFILE_PATH="claude/profiles/terraform.md"
+info "Checking ${TERRAFORM_PROFILE_PATH} sections..."
+[ -f "${TERRAFORM_PROFILE_PATH}" ] || fail "${TERRAFORM_PROFILE_PATH} does not exist"
+
+terraform_profile_required="Apply Gating
+Destroy Refusal
+State Mutation Gating
+Workspace Allowlist
+Anti-Patterns"
+
+while IFS= read -r section; do
+    [ -n "$section" ] || continue
+    if ! grep -qxF "## ${section}" "${TERRAFORM_PROFILE_PATH}"; then
+        fail "${TERRAFORM_PROFILE_PATH} missing required section: ## ${section}"
+    fi
+done <<EOF
+${terraform_profile_required}
+EOF
+
+# ------------------------------------------------------------------
+# Check 8 — no SKILL.md references _universal.md (negative claim)
 # ------------------------------------------------------------------
 # Restricted to SKILL.md files specifically. Future README.md or notes
 # under a skill directory may legitimately mention _universal.md (e.g.


### PR DESCRIPTION
## Summary

Phase 2 selective per-skill profile addendum for `terraform`. Adds `claude/profiles/terraform.md` with autonomous-agent-specific constraints layered on top of the post-#118 universal profile and the terraform workflow knowledge in `claude/skills/terraform/SKILL.md`.

Content is pure model posture per the content-vs-contract discipline established by #118 — no runtime claims.

## Changes

- `claude/profiles/terraform.md` — NEW. Five sections plus anti-patterns:
  - Apply Gating
  - Destroy Refusal
  - State Mutation Gating
  - Workspace Allowlist
  - Anti-Patterns

- `scripts/check-skill-structure.sh` — extends the L0 fixture with Check 7 asserting the five required H2 sections in `terraform.md`. Negative-claim check renumbered Check 7 → Check 8; header comment updated.

## Verification

`make check-skills` → all eight checks pass.

Runtime-claim grep → zero hits.

Hyphen-EOL grep → zero hits.

Backtick-balance check → clean.

## AC checklist (from #105)

- [x] `claude/profiles/terraform.md` covering:
  - [x] **Never auto-apply** — `terraform apply -auto-approve` refused outright; `terraform apply` requires explicit operator go-ahead per high-risk mutation gating in `_universal.md`. Plan output surfaced verbatim before any apply consideration. (Apply Gating)
  - [x] **State mutation gating** — `terraform state rm`, `terraform state mv`, `terraform import`, `terraform taint`/`untaint` (deprecated — never propose), `terraform force-unlock` all require per-target operator confirmation. State backup requirement surfaced before any mutation. (State Mutation Gating)
  - [x] **Workspace allowlist** — all operations target a configured-allowlist workspace; `workspace new` gated by same rule; `workspace select` treated as session-state mutation requiring explicit operator description. (Workspace Allowlist)
  - [x] **Never `terraform destroy` autonomously** — hard refusal regardless of operator confirmation; `-target` form and `plan -destroy -out=` artefact also refused. (Destroy Refusal)
  - [x] **Plan review required** — `terraform plan` output surfaced verbatim to operator before any apply consideration; applies to saved plan files as well. (Apply Gating)
- [x] No changes to `claude/skills/terraform/SKILL.md`
- [x] L0 fixture extended to validate the addendum's structure

## Suggested bridge crew adoption

(Per Epic #99 architect's revised Rec C — non-binding; bridge side decides population.)

No persona currently has `skills: [terraform]`. The bridge-side Q1 persona-skill adoption matrix is now load-bearing across **four** profile addenda (`security`, `kubernetes`, `vault`, `terraform`) — recommend filing the bridge tracking issue when convenient.

## Test plan

- [ ] CI passes (skill-structure lint workflow validates Check 7)
- [ ] Reviewer: read `terraform.md` end-to-end; flag any sentence that asserts consumer runtime behaviour rather than model posture
- [ ] Reviewer: confirm the five required sections in the fixture match the addendum's actual H2 headings

Closes #105
Refs #99
