### PR TITLE
feat(profiles): add claude/profiles/nix-modules-hardening.md — Phase 2 addendum 🎓

### DIFF
--- a/claude/profiles/nix-modules-hardening.md
+++ b/claude/profiles/nix-modules-hardening.md
@@ -1,0 +1,122 @@
+# Agent Operating Rules — Nix Modules Hardening Domain
+
+This file is the nix-modules-hardening agent profile addendum, written to
+complement the universal rules in `claude/profiles/_universal.md`
+and the workflow knowledge in
+`claude/skills/nix-modules-hardening/SKILL.md`.
+The rules below are the nix-modules-hardening-specific additions for
+autonomous agents.
+
+This file is intentionally not referenced from
+`claude/skills/nix-modules-hardening/SKILL.md` — Claude Code never
+auto-loads it.
+
+## Hardening Matrix Preservation
+
+When authoring or modifying a `systemd.services.<name>.serviceConfig`
+block, never remove or weaken a hardening directive without explicit
+operator justification. Directives in scope: `ProtectSystem`,
+`ProtectHome`, `PrivateTmp`, `PrivateDevices`, `NoNewPrivileges`,
+`RestrictAddressFamilies`, `SystemCallFilter`, `LockPersonality`,
+`RestrictNamespaces`, `RestrictRealtime`, `ProtectKernelTunables`,
+`ProtectControlGroups`, `ProtectKernelModules`, `MemoryDenyWriteExecute`,
+`CapabilityBoundingSet`.
+
+- "This test is failing" or "service startup is failing" is not
+  sufficient justification. Surface the specific failure mode to the
+  operator and investigate root cause — the hardening directive may be
+  correct and the service configuration needs adjustment, not the
+  directive.
+- Never weaken a hardening directive as a workaround for an undiagnosed
+  failure. Removing `SystemCallFilter` because a service crashes on
+  startup is an anti-pattern, not a fix.
+- The as-shipped hardening matrix (encoded in `tests/hardening-matrix.nix`
+  or an equivalent per-repo fixture) is the authoritative record of each
+  service's accepted hardening posture. Drift from this matrix — even
+  ostensibly safer additions — requires operator confirmation.
+- When reviewing a module for hardening completeness, flag any directive
+  that falls below the baseline tier for the service class. The SKILL.md
+  defense-in-depth matrix and Quick-Reference Baseline Template define
+  the tiers.
+
+## DynamicUser vs Static UID
+
+`DynamicUser = true` and `DynamicUser = false` are not symmetric.
+Do not flip either direction without surfacing the reason to the operator.
+
+- Some upstream nixpkgs units use static UIDs for load-bearing reasons.
+  PostgreSQL uses a static `postgres` UID because the data directory must
+  survive across system rebuilds with stable ownership. Redis uses a
+  static `redis-<serverName>` group so other services can join via
+  `SupplementaryGroups`. Flipping these to `DynamicUser` silently breaks
+  socket access or ownership invariants.
+- Before recommending `DynamicUser = true` for a service currently using
+  a static UID: check whether `SupplementaryGroups` references the static
+  group anywhere in the module tree. If it does, the flip is unsafe
+  without coordinated changes across all dependent modules.
+- Before recommending `DynamicUser = false` for a service currently using
+  `DynamicUser`: name the specific on-disk persistence or socket-group
+  requirement that demands it. "More convenient" or "avoids the chown
+  dance" is not sufficient.
+- `PrivateUsers = false` is load-bearing when a `DynamicUser` service
+  shares sockets owned by a statically-allocated group — host GID
+  remapping inside the user namespace breaks socket access. Removing it
+  silently breaks cross-service communication; require operator
+  confirmation before touching it.
+
+## MemoryDenyWriteExecute Opt-outs
+
+Baseline: `MemoryDenyWriteExecute = true`. Never set it to `false`
+without naming the specific JIT or runtime that requires the relaxation.
+
+- Accepted named justifications (per SKILL.md): BEAM (Elixir/Erlang),
+  V8 (Node.js), LuaJIT, JVM (OpenJDK/Temurin/Graal), ONNX runtime
+  (Piper, Sherpa-ONNX), PyPy.
+- "Tests pass with `false`" or "service crashes with `true`" is not a
+  justification — it is a symptom. Surface the failure to the operator;
+  investigate whether the JIT requirement is real or whether a different
+  directive is the true cause.
+- Use `lib.mkDefault false` rather than a bare `false` so operators can
+  re-enable the protection without `mkForce`. Accompany with an inline
+  comment naming the JIT (e.g. `# BEAM JIT`, `# V8 JIT`).
+- Never recommend disabling `MemoryDenyWriteExecute` for services that
+  do not use a JIT — interpreted languages (Python, pure shell) do not
+  require the relaxation.
+
+## Hardening Matrix Tests
+
+Changes to `tests/hardening-matrix.nix` (or the equivalent per-repo
+hardening matrix fixture) are high-risk mutations per `_universal.md` —
+they redefine the authoritative record of accepted hardening posture.
+
+- Per-service per-key changes require operator confirmation. Surface the
+  before-and-after diff for each affected service and each modified key
+  before invoking any edit.
+- Never update the hardening matrix test to make it pass after a
+  hardening regression. The test is the signal; the fix belongs in the
+  module. If the module change is intentional (e.g. adding a JIT
+  dependency that requires `MemoryDenyWriteExecute = false`), surface the
+  justification first and update the module and the matrix in lockstep.
+- Changes that loosen a constraint (remove a key, or move a value to a
+  less restrictive setting) carry higher risk than those that tighten.
+  Apply per-key scrutiny proportionally.
+
+## Anti-Patterns
+
+- Removing or weakening a hardening directive without naming the specific
+  failure mode and obtaining operator justification
+- "This fixes the test" or "service starts now" as justification for a
+  hardening relaxation
+- Flipping `DynamicUser` without checking `SupplementaryGroups`
+  references in the module tree
+- Removing `PrivateUsers = false` from a `DynamicUser` service that
+  shares sockets via group membership
+- `MemoryDenyWriteExecute = false` without naming the specific JIT
+  (BEAM, V8, LuaJIT, JVM, etc.)
+- Updating the hardening matrix test to match a regression rather than
+  fixing the regression in the module
+- Loosening the hardening matrix test without per-key operator
+  confirmation
+- `MemoryDenyWriteExecute = false` for a service that does not use a JIT
+- Bare `false` instead of `lib.mkDefault false` for JIT opt-outs
+  (prevents operator re-enable without `mkForce`)

--- a/scripts/check-skill-structure.sh
+++ b/scripts/check-skill-structure.sh
@@ -14,7 +14,8 @@
 #   5. claude/profiles/kubernetes.md exists with the required H2 sections
 #   6. claude/profiles/vault.md exists with the required H2 sections
 #   7. claude/profiles/terraform.md exists with the required H2 sections
-#   8. No claude/skills/<name>/SKILL.md references _universal.md
+#   8. claude/profiles/nix-modules-hardening.md exists with the required H2 sections
+#   9. No claude/skills/<name>/SKILL.md references _universal.md
 #      (negative claim — the asymmetric reference graph is deliberate;
 #      Claude Code must not auto-load universal content via a sibling
 #      link from a SKILL.md, since that would pollute human-CC users
@@ -237,7 +238,29 @@ ${terraform_profile_required}
 EOF
 
 # ------------------------------------------------------------------
-# Check 8 — no SKILL.md references _universal.md (negative claim)
+# Check 8 — nix-modules-hardening.md required H2 sections
+# ------------------------------------------------------------------
+NIX_HARDENING_PROFILE_PATH="claude/profiles/nix-modules-hardening.md"
+info "Checking ${NIX_HARDENING_PROFILE_PATH} sections..."
+[ -f "${NIX_HARDENING_PROFILE_PATH}" ] || fail "${NIX_HARDENING_PROFILE_PATH} does not exist"
+
+nix_hardening_profile_required="Hardening Matrix Preservation
+DynamicUser vs Static UID
+MemoryDenyWriteExecute Opt-outs
+Hardening Matrix Tests
+Anti-Patterns"
+
+while IFS= read -r section; do
+    [ -n "$section" ] || continue
+    if ! grep -qxF "## ${section}" "${NIX_HARDENING_PROFILE_PATH}"; then
+        fail "${NIX_HARDENING_PROFILE_PATH} missing required section: ## ${section}"
+    fi
+done <<EOF
+${nix_hardening_profile_required}
+EOF
+
+# ------------------------------------------------------------------
+# Check 9 — no SKILL.md references _universal.md (negative claim)
 # ------------------------------------------------------------------
 # Restricted to SKILL.md files specifically. Future README.md or notes
 # under a skill directory may legitimately mention _universal.md (e.g.


### PR DESCRIPTION
## Summary

Phase 2 selective per-skill profile addendum for `nix-modules-hardening`. Adds `claude/profiles/nix-modules-hardening.md` with autonomous-agent-specific constraints layered on top of the post-#118 universal profile and the workflow knowledge in `claude/skills/nix-modules-hardening/SKILL.md`.

Content is pure model posture per the content-vs-contract discipline established by #118 — no runtime claims.

## Changes

- `claude/profiles/nix-modules-hardening.md` — NEW. Five sections plus anti-patterns:
  - Hardening Matrix Preservation
  - DynamicUser vs Static UID
  - MemoryDenyWriteExecute Opt-outs
  - Hardening Matrix Tests
  - Anti-Patterns

- `scripts/check-skill-structure.sh` — extends the L0 fixture with Check 8 asserting the five required H2 sections in `nix-modules-hardening.md`. Negative-claim check renumbered Check 8 → Check 9; header comment updated.

## Verification

`make check-skills` → all nine checks pass.

Runtime-claim grep → zero hits (two "runtime" occurrences are domain terms: "JIT or runtime" and "ONNX runtime").

Hyphen-EOL grep → zero hits.

Backtick-balance check → clean.

## AC checklist (from #106)

- [x] `claude/profiles/nix-modules-hardening.md` covering:
  - [x] **Capability-bound enforcement** — never remove or weaken a hardening directive (`ProtectSystem`, `RestrictAddressFamilies`, `SystemCallFilter`, `MemoryDenyWriteExecute`, etc.) without explicit operator justification; "service starts now" is not sufficient; surface the specific failure mode (Hardening Matrix Preservation)
  - [x] **Never lift constraints for convenience or to make a test pass** — startup/test failure surfaces to operator; the fix belongs in the module not the directive (Hardening Matrix Preservation + Hardening Matrix Tests)
  - [x] **Hardening matrix changes require operator confirmation** — `tests/hardening-matrix.nix`-shape changes are high-risk mutations; per-key before/after diff required; never update to match a regression (Hardening Matrix Tests)
  - [x] **DynamicUser opt-out requires explicit reasoning** — static UID load-bearing cases (postgres, redis-`<serverName>`) surfaced; `PrivateUsers = false` consequence explained; `SupplementaryGroups` cross-check required before flipping (DynamicUser vs Static UID)
  - [x] **Never `MemoryDenyWriteExecute = false` without naming the JIT** — named justifications listed (BEAM, V8, LuaJIT, JVM, ONNX); `lib.mkDefault false` + inline comment required; no relaxation for non-JIT services (MemoryDenyWriteExecute Opt-outs)
- [x] No changes to `claude/skills/nix-modules-hardening/SKILL.md`
- [x] L0 fixture extended to validate the addendum's structure

## Suggested bridge crew adoption

(Per Epic #99 architect's revised Rec C — non-binding; bridge side decides population.)

No persona currently has `skills: [nix-modules-hardening]`. The bridge-side Q1 persona-skill adoption matrix is now load-bearing across **five** profile addenda: `security`, `kubernetes`, `vault`, `terraform`, `nix-modules-hardening`.

## Test plan

- [ ] CI passes (skill-structure lint workflow validates Check 8)
- [ ] Reviewer: read `nix-modules-hardening.md` end-to-end; flag any sentence that asserts consumer runtime behaviour rather than model posture
- [ ] Reviewer: confirm the five required sections in the fixture match the addendum's actual H2 headings

Closes #106
Refs #99
