### PR TITLE
feat(profiles): add claude/profiles/concourse.md — Phase 2 concourse addendum 🎓

### DIFF
--- a/claude/profiles/concourse.md
+++ b/claude/profiles/concourse.md
@@ -33,8 +33,9 @@ and Concourse targets. Concourse-specific reinforcement:
 
 - `fly destroy-pipeline` is a high-risk mutation per `_universal.md` —
   it permanently removes the pipeline and all its build history.
-  Per-target confirmation applies; never include in automation or
-  propose it as a routine cleanup step.
+  Per-pipeline confirmation applies; surface the pipeline name to the
+  operator before invoking. Never include in automation or propose it
+  as a routine cleanup step.
 - `fly pause-pipeline` and `fly unpause-pipeline` affect all jobs in
   the pipeline simultaneously — per-pipeline confirmation applies.
 - `fly trigger-job` bypasses normal resource-trigger logic; surface

--- a/claude/profiles/concourse.md
+++ b/claude/profiles/concourse.md
@@ -19,9 +19,10 @@ and Concourse targets. Concourse-specific reinforcement:
   is allowlisted, refuse and surface the pipeline name and applicable
   allowlist to the operator.
 - Read operations (`fly get-pipeline`, `fly jobs`, `fly builds`,
-  `fly watch`) are not allowlist-gated but must still carry an explicit
-  `-t TARGET` flag on every invocation — never rely on the default
-  target.
+  `fly watch`) may be less restricted than write operations, but if a
+  read allowlist is configured it must still be honoured. Every `fly`
+  invocation must carry an explicit `-t TARGET` flag — never rely on
+  the default target.
 - Pipeline creation via `fly set-pipeline` on a pipeline name not
   already in the allowlist is a mutation against the allowlist itself —
   treat the same as a new entry requiring operator confirmation.
@@ -45,11 +46,12 @@ and Concourse targets. Concourse-specific reinforcement:
 
 ## Fly CLI Credential Handling
 
-- Never pass a Concourse token inline in a `fly` command argument.
-  `fly login` accepts tokens via `--client-secret` and similar flags —
-  if the operator's task requires authentication, surface the correct
-  flag and ask the operator to supply the value, rather than
-  constructing a command line with the token embedded.
+- Never pass a Concourse token or client secret inline in a `fly`
+  command argument. If authentication is required, direct the operator
+  to run `fly login` interactively in their own session. Any
+  non-interactive authentication step that requires embedding a
+  credential value in argv must be performed by the operator directly —
+  never construct such a command line on their behalf.
 - The `-t TARGET` value in `.flyrc` can reference a named target whose
   stored credentials include a token. Never echo the full contents of
   `.flyrc` or any `fly targets --json` output that includes token

--- a/claude/profiles/concourse.md
+++ b/claude/profiles/concourse.md
@@ -14,10 +14,10 @@ The universal allowlist posture in `_universal.md` applies to pipelines
 and Concourse targets. Concourse-specific reinforcement:
 
 - Write operations — `fly set-pipeline`, `fly unpause-pipeline`,
-  `fly trigger-job`, and `fly abort-build` — must target a pipeline
-  in the configured allowlist. If you cannot confirm the target pipeline
-  is allowlisted, refuse and surface the pipeline name and applicable
-  allowlist to the operator.
+  `fly trigger-job`, `fly abort-build`, and `fly destroy-pipeline` —
+  must target a pipeline in the configured allowlist. If you cannot
+  confirm the target pipeline is allowlisted, refuse and surface the
+  pipeline name and applicable allowlist to the operator.
 - Read operations (`fly get-pipeline`, `fly jobs`, `fly builds`,
   `fly watch`) may be less restricted than write operations, but if a
   read allowlist is configured it must still be honoured. Every `fly`
@@ -25,7 +25,9 @@ and Concourse targets. Concourse-specific reinforcement:
   the default target.
 - Pipeline creation via `fly set-pipeline` on a pipeline name not
   already in the allowlist is a mutation against the allowlist itself —
-  treat the same as a new entry requiring operator confirmation.
+  refuse until the operator explicitly adds the pipeline name to the
+  allowlist. Operator confirmation alone does not substitute for an
+  allowlist update.
 
 ## Destructive Operation Gating
 

--- a/claude/profiles/concourse.md
+++ b/claude/profiles/concourse.md
@@ -1,0 +1,78 @@
+# Agent Operating Rules — Concourse Domain
+
+This file is the concourse-domain agent profile addendum, written to
+complement the universal rules in `claude/profiles/_universal.md`
+and the workflow knowledge in `claude/skills/concourse/SKILL.md`.
+The rules below are the concourse-specific additions for autonomous agents.
+
+This file is intentionally not referenced from
+`claude/skills/concourse/SKILL.md` — Claude Code never auto-loads it.
+
+## Pipeline Allowlist
+
+The universal allowlist posture in `_universal.md` applies to pipelines
+and Concourse targets. Concourse-specific reinforcement:
+
+- Write operations — `fly set-pipeline`, `fly unpause-pipeline`,
+  `fly trigger-job`, and `fly abort-build` — must target a pipeline
+  in the configured allowlist. If you cannot confirm the target pipeline
+  is allowlisted, refuse and surface the pipeline name and applicable
+  allowlist to the operator.
+- Read operations (`fly get-pipeline`, `fly jobs`, `fly builds`,
+  `fly watch`) are not allowlist-gated but must still carry an explicit
+  `-t TARGET` flag on every invocation — never rely on the default
+  target.
+- Pipeline creation via `fly set-pipeline` on a pipeline name not
+  already in the allowlist is a mutation against the allowlist itself —
+  treat the same as a new entry requiring operator confirmation.
+
+## Destructive Operation Gating
+
+- `fly destroy-pipeline` is a high-risk mutation per `_universal.md` —
+  it permanently removes the pipeline and all its build history.
+  Per-target confirmation applies; never include in automation or
+  propose it as a routine cleanup step.
+- `fly pause-pipeline` and `fly unpause-pipeline` affect all jobs in
+  the pipeline simultaneously — per-pipeline confirmation applies.
+- `fly trigger-job` bypasses normal resource-trigger logic; surface
+  the job name and pipeline to the operator before invoking.
+- `fly abort-build` terminates a running build; surface the build
+  reference to the operator before invoking.
+- `fly prune-worker` removes a worker from the cluster — high-risk;
+  per-target confirmation applies.
+- `fly clear-task-cache` can force all tasks to re-download
+  dependencies — surface the scope to the operator before invoking.
+
+## Fly CLI Credential Handling
+
+- Never pass a Concourse token inline in a `fly` command argument.
+  `fly login` accepts tokens via `--client-secret` and similar flags —
+  if the operator's task requires authentication, surface the correct
+  flag and ask the operator to supply the value, rather than
+  constructing a command line with the token embedded.
+- The `-t TARGET` value in `.flyrc` can reference a named target whose
+  stored credentials include a token. Never echo the full contents of
+  `.flyrc` or any `fly targets --json` output that includes token
+  fields. Refer to targets by name only.
+- If tool output from a `fly` command contains a field that appears
+  token-shaped (long opaque string, `bearer`, `access_token`, or
+  `token` key), redact it before including the output in your response.
+  Apply the same treatment as Vault tokens per `_universal.md`.
+- `fly login -t TARGET -c URL` is the correct form for target
+  configuration — it prompts interactively and never requires a token
+  on the command line. Never construct a non-interactive `fly login`
+  invocation that embeds credential values in argv.
+
+## Anti-Patterns
+
+- `fly set-pipeline`, `fly unpause-pipeline`, `fly trigger-job`, or
+  `fly abort-build` targeting a pipeline outside the configured allowlist
+- `fly destroy-pipeline` without explicit per-pipeline operator
+  confirmation
+- `fly` invocations without an explicit `-t TARGET` flag
+- Passing a token or client secret inline in a `fly` command argument
+- Echoing `.flyrc` contents or `fly targets` output that includes token
+  fields
+- Including `fly destroy-pipeline` in automation or scripts
+- `fly login` with credential values embedded in argv rather than
+  supplied interactively

--- a/claude/profiles/concourse.md
+++ b/claude/profiles/concourse.md
@@ -58,7 +58,10 @@ and Concourse targets. Concourse-specific reinforcement:
 - The `-t TARGET` value in `.flyrc` can reference a named target whose
   stored credentials include a token. Never echo the full contents of
   `.flyrc` or any `fly targets --json` output that includes token
-  fields. Refer to targets by name only.
+  fields. Refer to targets by name only. If a target name is itself
+  token-shaped (long opaque string), treat it as sensitive: redact or
+  placeholder it in summaries and ask the operator to confirm the
+  intended target out-of-band before invoking any `fly` command.
 - If tool output from a `fly` command contains a field that appears
   token-shaped (long opaque string, `bearer`, `access_token`, or
   `token` key), redact it before including the output in your response.

--- a/scripts/check-skill-structure.sh
+++ b/scripts/check-skill-structure.sh
@@ -15,7 +15,8 @@
 #   6. claude/profiles/vault.md exists with the required H2 sections
 #   7. claude/profiles/terraform.md exists with the required H2 sections
 #   8. claude/profiles/nix-modules-hardening.md exists with the required H2 sections
-#   9. No claude/skills/<name>/SKILL.md references _universal.md
+#   9. claude/profiles/concourse.md exists with the required H2 sections
+#  10. No claude/skills/<name>/SKILL.md references _universal.md
 #      (negative claim — the asymmetric reference graph is deliberate;
 #      Claude Code must not auto-load universal content via a sibling
 #      link from a SKILL.md, since that would pollute human-CC users
@@ -260,7 +261,28 @@ ${nix_hardening_profile_required}
 EOF
 
 # ------------------------------------------------------------------
-# Check 9 — no SKILL.md references _universal.md (negative claim)
+# Check 9 — concourse.md required H2 sections
+# ------------------------------------------------------------------
+CONCOURSE_PROFILE_PATH="claude/profiles/concourse.md"
+info "Checking ${CONCOURSE_PROFILE_PATH} sections..."
+[ -f "${CONCOURSE_PROFILE_PATH}" ] || fail "${CONCOURSE_PROFILE_PATH} does not exist"
+
+concourse_profile_required="Pipeline Allowlist
+Destructive Operation Gating
+Fly CLI Credential Handling
+Anti-Patterns"
+
+while IFS= read -r section; do
+    [ -n "$section" ] || continue
+    if ! grep -qxF "## ${section}" "${CONCOURSE_PROFILE_PATH}"; then
+        fail "${CONCOURSE_PROFILE_PATH} missing required section: ## ${section}"
+    fi
+done <<EOF
+${concourse_profile_required}
+EOF
+
+# ------------------------------------------------------------------
+# Check 10 — no SKILL.md references _universal.md (negative claim)
 # ------------------------------------------------------------------
 # Restricted to SKILL.md files specifically. Future README.md or notes
 # under a skill directory may legitimately mention _universal.md (e.g.


### PR DESCRIPTION
## Summary

Phase 2 selective per-skill profile addendum for `concourse`. Adds `claude/profiles/concourse.md` with autonomous-agent-specific constraints layered on top of the post-#118 universal profile and the Concourse workflow knowledge in `claude/skills/concourse/SKILL.md`.

Content is pure model posture per the content-vs-contract discipline established by #118 — no runtime claims.

## Changes

- `claude/profiles/concourse.md` — NEW. Four sections plus anti-patterns:
  - Pipeline Allowlist
  - Destructive Operation Gating
  - Fly CLI Credential Handling
  - Anti-Patterns

- `scripts/check-skill-structure.sh` — extends the L0 fixture with Check 9 asserting the four required H2 sections in `concourse.md`. Negative-claim check renumbered Check 9 → Check 10; header comment updated.

## Verification

`make check-skills` → all ten checks pass.

Runtime-claim grep → zero hits.

Hyphen-EOL grep → zero hits.

Backtick-balance check → clean.

## AC checklist (from #102)

- [x] `claude/profiles/concourse.md` covering:
  - [x] **Pipeline allowlist** — `fly set-pipeline`, `fly unpause-pipeline`, `fly trigger-job`, `fly abort-build` confined to configured allowlist; new pipeline creation gated; every `fly` invocation carries explicit `-t TARGET` (Pipeline Allowlist)
  - [x] **Destroy-pipeline refusal** — `fly destroy-pipeline` is high-risk per `_universal.md`; per-target operator confirmation required; never in automation (Destructive Operation Gating)
  - [x] **Audit on every `fly` invocation** — redact token-shaped values from tool output before including in response; `.flyrc` and `fly targets` output treated as credential-bearing (Fly CLI Credential Handling)
  - [x] **Never `fly login` with token inline in argv** — interactive-only; credential values never embedded in command arguments (Fly CLI Credential Handling)
- [x] No changes to `claude/skills/concourse/SKILL.md`
- [x] L0 fixture extended to validate the addendum's structure

## Suggested bridge crew adoption

(Per Epic #99 architect's revised Rec C — non-binding; bridge side decides population.)

No persona currently has `skills: [concourse]`. The bridge-side Q1 persona-skill adoption matrix is now load-bearing across **six** profile addenda: `security`, `kubernetes`, `vault`, `terraform`, `nix-modules-hardening`, `concourse`.

## Test plan

- [ ] CI passes (skill-structure lint workflow validates Check 9)
- [ ] Reviewer: read `concourse.md` end-to-end; flag any sentence that asserts consumer runtime behaviour rather than model posture
- [ ] Reviewer: confirm the four required sections in the fixture match the addendum's actual H2 headings

Closes #102
Refs #99
