### PR TITLE
chore(profiles): align security + kubernetes headers to 'written to complement' phrasing 🎓

### DIFF
--- a/claude/profiles/github.md
+++ b/claude/profiles/github.md
@@ -1,8 +1,8 @@
 # Agent Operating Rules — Git + GitHub Workflow
 
-This file is the GitHub-specific agent profile addendum. It is loaded
-alongside `_universal.md` for any persona that consumes the `github`
-skill.
+This file is the GitHub-specific agent profile addendum, written to
+complement the universal rules in `claude/profiles/_universal.md`
+and the workflow knowledge in `claude/skills/github/SKILL.md`.
 
 This file is **intentionally not referenced from
 `claude/skills/github/SKILL.md`** — Claude Code never auto-loads it.

--- a/claude/profiles/kubernetes.md
+++ b/claude/profiles/kubernetes.md
@@ -1,9 +1,9 @@
 # Agent Operating Rules — Kubernetes Domain
 
-This file is the kubernetes-domain agent profile addendum. The universal
-agent rules in `claude/profiles/_universal.md` and the workflow knowledge
-in `claude/skills/kubernetes/SKILL.md` apply alongside it; the rules
-below are the kubernetes-specific additions for autonomous agents.
+This file is the kubernetes-domain agent profile addendum, written to
+complement the universal rules in `claude/profiles/_universal.md`
+and the workflow knowledge in `claude/skills/kubernetes/SKILL.md`.
+The rules below are the kubernetes-specific additions for autonomous agents.
 
 This file is intentionally not referenced from
 `claude/skills/kubernetes/SKILL.md` — Claude Code never auto-loads it.

--- a/claude/profiles/security.md
+++ b/claude/profiles/security.md
@@ -1,9 +1,9 @@
 # Agent Operating Rules — Security Domain
 
-This file is the security-domain agent profile addendum. The universal
-agent rules in `claude/profiles/_universal.md` and the workflow knowledge
-in `claude/skills/security/SKILL.md` apply alongside it; the rules below
-are the security-specific additions for autonomous agents.
+This file is the security-domain agent profile addendum, written to
+complement the universal rules in `claude/profiles/_universal.md`
+and the workflow knowledge in `claude/skills/security/SKILL.md`.
+The rules below are the security-specific additions for autonomous agents.
 
 This file is intentionally not referenced from
 `claude/skills/security/SKILL.md` — Claude Code never auto-loads it.


### PR DESCRIPTION
Aligns the opening paragraph of `security.md` and `kubernetes.md` to the
canonical "written to complement" form used by vault/terraform/nix-modules-hardening/concourse.

The old two-sentence "apply alongside" form was Phase 2 item 1 and 2 landing before the phrasing was settled during vault.md R6.

## Changes

- `claude/profiles/security.md` — paragraph rewritten to match vault form
- `claude/profiles/kubernetes.md` — paragraph rewritten to match vault form

## Verification

- `make check-skills` passes (L0 fixture)
- All six Phase 2 addenda + `_universal.md` consistent on "written to complement"

Closes #126 
Refs #99
