### PR TITLE
feat(skills): add gh-actions skill for workflow-safety patterns 🎓

### DIFF
--- a/claude/skills/gh-actions/SKILL.md
+++ b/claude/skills/gh-actions/SKILL.md
@@ -51,7 +51,7 @@ Never interpolate untrusted `${{ }}` directly into a `run:` block. Pass via an e
     PR_BODY: ${{ github.event.pull_request.body }}
   run: |
     # $PR_BODY is a shell variable — no text substitution into script source
-    echo "$PR_BODY" | grep -qF "[allow-coverage-drop]"
+    printf '%s\n' "$PR_BODY" | grep -qF "[allow-coverage-drop]"
 ```
 
 The `env:` key receives the `${{ }}` substitution; the shell sees a quoted variable reference, not inline text. This prevents metacharacter injection.
@@ -62,6 +62,7 @@ Action outputs (e.g. from `release-please-action`) are not sanitised at source. 
 
 ```yaml
 - name: Validate version output
+  shell: bash
   env:
     VERSION: ${{ steps.release.outputs.version }}
   run: |
@@ -76,7 +77,7 @@ Do not construct `tag_name` by consuming the action's `tag_name` output directly
 
 ### Heredoc / here-string sensitivity
 
-Avoid `<<< "${{ ... }}"` (here-string) and `<<EOF ... ${{ ... }} ... EOF` (heredoc) when the interpolated value is user-authored. The `${{ }}` substitution happens before shell parsing; the resulting here-string is re-parsed as shell input, where `#` can start comments and `"` can terminate the string.
+Avoid `<<< "${{ ... }}"` (here-string) and `<<EOF ... ${{ ... }} ... EOF` (heredoc) when the interpolated value is user-authored. The `${{ }}` substitution happens before the shell sees the `run:` script at all — the runner resolves every `${{ }}` expression textually into the script source, then passes the assembled string to the shell. Attacker-controlled content can therefore break out of quoting, introduce new commands, or use `#` to comment out the rest of a line — all before the shell runs.
 
 Use env-var indirection and read the env var inside the heredoc/here-string:
 
@@ -127,14 +128,16 @@ Omitting `synchronize` means the workflow only fires when the PR is first opened
 
 ### actionlint
 
-Pin via the `docker://` image reference to avoid version drift:
+Pin via the `docker://` image reference. For supply-chain immutability, pin by digest rather than tag — a tag can be rebuilt or retagged:
 
 ```yaml
 - name: Lint workflows
-  uses: docker://rhysd/actionlint:1.7.7
+  uses: docker://rhysd/actionlint@sha256:<digest>  # 1.7.7
   with:
     args: -color
 ```
+
+Verify the digest at install time: `docker pull rhysd/actionlint:1.7.7 && docker inspect --format='{{index .RepoDigests 0}}' rhysd/actionlint:1.7.7`. Tag-pinning (`docker://rhysd/actionlint:1.7.7`) is acceptable when digest pinning is impractical, but prefer the digest form for security-sensitive lint gates.
 
 actionlint catches: undefined expressions, unknown action inputs, shell syntax errors (it runs shellcheck internally), incorrect `on:` event types, and string/number type mismatches.
 
@@ -144,8 +147,10 @@ Pre-installed on `ubuntu-latest`. Add an explicit shell-script lint step for any
 
 ```yaml
 - name: Lint shell scripts
-  run: shellcheck .github/scripts/*.sh
+  run: find .github/scripts -name '*.sh' -print0 | xargs -r0 shellcheck
 ```
+
+The glob form (`shellcheck .github/scripts/*.sh`) fails if no `.sh` files exist — Bash keeps the literal pattern as an argument and shellcheck exits non-zero. `find | xargs -r0` skips the shellcheck invocation when there are no matches.
 
 ### Action version pinning
 
@@ -168,3 +173,7 @@ Tag-based pinning (`@v4`) is acceptable for trusted first-party actions; avoid `
 - Consuming action outputs (e.g. `release-please-action`'s `tag_name`) without regex-validating format first
 - Hardcoded line-number references in code comments within workflow `run:` blocks — drift on the same PR that introduces them
 - Missing `issues: write` permission when using `gh api` to post issue comments — `pull-requests: write` does not cover the issue-comments endpoint
+
+## See Also
+
+- `release-please` skill — action-output validation (the regex-validate pattern above is used when consuming `release-please-action`'s `version` output to reconstruct `tag_name` safely)

--- a/claude/skills/gh-actions/SKILL.md
+++ b/claude/skills/gh-actions/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: gh-actions
+description: GitHub Actions workflow safety — untrusted-context handling, safe interpolation patterns, override-gate design, and workflow lint guards. Use when writing or reviewing GitHub Actions workflows, handling pull_request events, or designing permission-relevant CI gates.
+---
+
+# GitHub Actions Skill
+
+## Untrusted Context Handling
+
+`${{ }}` is **text substitution** into the rendered shell script source — it is not a data binding or a safe parameter expansion. Before any `${{ }}` expression reaches a `run:` block, understand which contexts contain user-authored content.
+
+### User-authored contexts (treat as untrusted)
+
+- `github.event.pull_request.body` — PR description, editable by any contributor
+- `github.event.pull_request.title` — PR title, same
+- `github.event.issue.body` / `github.event.comment.body` — issue and comment text
+- `github.head_ref` — branch name from a fork author (can contain shell metacharacters)
+- `github.event.label.name` — label names set by external contributors on public repos
+- Any `github.event.*` field that reflects contributor-supplied content
+
+### GHA-internal contexts (generally safe)
+
+- `github.sha` — commit SHA set by GitHub infrastructure
+- `github.event_name` — the event type string (a GHA constant)
+- `github.actor` — the triggering username (safe for logging, not for auth decisions)
+- `github.token` — the workflow token (never echo; treat as secret)
+- `secrets.*` — vault values (never echo; treat as secret)
+- `github.repository` — `owner/repo` string set by GitHub infrastructure
+
+### Why body/title interpolation is dangerous
+
+`${{ github.event.pull_request.body }}` is resolved to its literal string value and spliced into the workflow YAML before the shell sees it. A body containing:
+
+```
+foo" ; malicious-command #
+```
+
+can produce syntactically valid but attacker-controlled shell. A body containing a lone `#` after a `"` can eat everything that follows as a shell comment, producing a syntax error or — worse — silently omitting a command.
+
+Source: klazomenai/bridge#163, remediated in klazomenai/bridge#164.
+
+## Safe Interpolation Patterns
+
+### Env-var indirection (canonical pattern)
+
+Never interpolate untrusted `${{ }}` directly into a `run:` block. Pass via an environment variable instead:
+
+```yaml
+- name: Use PR body safely
+  env:
+    PR_BODY: ${{ github.event.pull_request.body }}
+  run: |
+    # $PR_BODY is a shell variable — no text substitution into script source
+    echo "$PR_BODY" | grep -qF "[allow-coverage-drop]"
+```
+
+The `env:` key receives the `${{ }}` substitution; the shell sees a quoted variable reference, not inline text. This prevents metacharacter injection.
+
+### Regex-validate action outputs before use
+
+Action outputs (e.g. from `release-please-action`) are not sanitised at source. If an output reaches a `run:` block or a downstream step, validate it first:
+
+```yaml
+- name: Validate version output
+  env:
+    VERSION: ${{ steps.release.outputs.version }}
+  run: |
+    if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      echo "Unexpected version format: $VERSION" >&2
+      exit 1
+    fi
+    echo "tag_name=v$VERSION" >> "$GITHUB_OUTPUT"
+```
+
+Do not construct `tag_name` by consuming the action's `tag_name` output directly — reconstruct it locally after validating `version`.
+
+### Heredoc / here-string sensitivity
+
+Avoid `<<< "${{ ... }}"` (here-string) and `<<EOF ... ${{ ... }} ... EOF` (heredoc) when the interpolated value is user-authored. The `${{ }}` substitution happens before shell parsing; the resulting here-string is re-parsed as shell input, where `#` can start comments and `"` can terminate the string.
+
+Use env-var indirection and read the env var inside the heredoc/here-string:
+
+```yaml
+env:
+  PR_BODY: ${{ github.event.pull_request.body }}
+run: |
+  grep -qF "[marker]" <<< "$PR_BODY"
+```
+
+## Override-Gate Design
+
+### Labels over PR-body markers
+
+For permission-relevant overrides (e.g. "allow coverage to drop on this PR"), prefer **labels** over PR-body text markers:
+
+| Property | Label gate | PR-body marker |
+|---|---|---|
+| RBAC | Only maintainers with triage+ can add labels | Any contributor can edit the PR body |
+| Audit trail | Label addition appears in the timeline | PR body edits may not be surfaced |
+| Injection surface | Label name is a fixed identifier | Body text reaches `run:` blocks as unstructured text |
+| Machine check | `contains(github.event.pull_request.labels.*.name, 'foo')` | grep against `${{ github.event.pull_request.body }}` |
+
+```yaml
+# Label-based gate (preferred)
+- name: Check for coverage override
+  if: contains(github.event.pull_request.labels.*.name, 'allow-coverage-drop')
+  run: echo "Coverage drop allowed"
+```
+
+### `on.pull_request.types` — listing types replaces defaults
+
+The default `pull_request` trigger fires on `[opened, synchronize, reopened]`. If you add `labeled` to `types:`, you **must** also list the defaults — otherwise PRs no longer trigger on push:
+
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]  # all four required
+```
+
+Omitting `synchronize` means the workflow only fires when the PR is first opened or when a label is added — not on subsequent commits.
+
+### `pull_request` vs `pull_request_target`
+
+`pull_request_target` runs the base-branch workflow with **write tokens** against fork-author HEAD content. Any `actions/checkout` step that checks out the PR HEAD (`ref: ${{ github.event.pull_request.head.sha }}`) in a `pull_request_target` context is a supply-chain risk: attacker-controlled code runs with write token. Use `pull_request` (which demotes tokens on forks) unless you explicitly need base-branch context with write access and understand the trust boundary.
+
+## Workflow Lint Guards
+
+### actionlint
+
+Pin via the `docker://` image reference to avoid version drift:
+
+```yaml
+- name: Lint workflows
+  uses: docker://rhysd/actionlint:1.7.7
+  with:
+    args: -color
+```
+
+actionlint catches: undefined expressions, unknown action inputs, shell syntax errors (it runs shellcheck internally), incorrect `on:` event types, and string/number type mismatches.
+
+### shellcheck
+
+Pre-installed on `ubuntu-latest`. Add an explicit shell-script lint step for any scripts under `.github/scripts/`:
+
+```yaml
+- name: Lint shell scripts
+  run: shellcheck .github/scripts/*.sh
+```
+
+### Action version pinning
+
+Prefer pinning to a commit SHA for security-sensitive actions:
+
+```yaml
+uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+```
+
+Tag-based pinning (`@v4`) is acceptable for trusted first-party actions; avoid `@latest` entirely. Third-party actions from untrusted authors should always be SHA-pinned.
+
+## Anti-Patterns to Flag
+
+- Interpolating `${{ github.event.pull_request.body }}` / `.title` / `.head.ref` / comment text directly into a `run:` block (injection surface — use env-var indirection)
+- `<<< "${{ github.event.pull_request.body }}"` here-string — `${{ }}` is resolved before shell parsing; use `<<< "$PR_BODY"` after setting `PR_BODY` in `env:`
+- PR-body markers for permission-relevant overrides (use labels — RBAC-gated, audit-trailed, injection-free)
+- `on.pull_request.types: [labeled]` without also listing `[opened, synchronize, reopened]` — silently stops triggering on PR commits
+- `pull_request_target` with `actions/checkout` of the PR HEAD — write tokens + fork code = supply-chain risk
+- `@latest` action version pins — unpinned, can pull breaking changes or malicious updates silently
+- Consuming action outputs (e.g. `release-please-action`'s `tag_name`) without regex-validating format first
+- Hardcoded line-number references in code comments within workflow `run:` blocks — drift on the same PR that introduces them
+- Missing `issues: write` permission when using `gh api` to post issue comments — `pull-requests: write` does not cover the issue-comments endpoint

--- a/claude/skills/gh-actions/SKILL.md
+++ b/claude/skills/gh-actions/SKILL.md
@@ -146,10 +146,13 @@ Pre-installed on `ubuntu-latest`. Add an explicit shell-script lint step for any
 
 ```yaml
 - name: Lint shell scripts
-  run: find .github/scripts -name '*.sh' -print0 | xargs -r0 shellcheck
+  run: |
+    if [ -d .github/scripts ]; then
+      find .github/scripts -name '*.sh' -print0 | xargs -r0 shellcheck
+    fi
 ```
 
-The glob form (`shellcheck .github/scripts/*.sh`) fails if no `.sh` files exist — Bash keeps the literal pattern as an argument and shellcheck exits non-zero. `find | xargs -r0` skips the shellcheck invocation when there are no matches.
+The glob form (`shellcheck .github/scripts/*.sh`) fails if no `.sh` files exist — Bash keeps the literal pattern as an argument and shellcheck exits non-zero. `find | xargs -r0` skips the shellcheck invocation when there are no matches. The `if [ -d ... ]` guard handles the case where `.github/scripts/` does not exist at all — GitHub Actions defaults to `bash -o pipefail`, so `find` exiting non-zero on a missing directory would otherwise fail the step.
 
 ### Action version pinning
 

--- a/claude/skills/gh-actions/SKILL.md
+++ b/claude/skills/gh-actions/SKILL.md
@@ -175,4 +175,4 @@ Tag-based pinning (`@v4`) is acceptable for trusted first-party actions; avoid `
 
 ## See Also
 
-- `release-please` skill — action-output validation (the regex-validate pattern above is used when consuming `release-please-action`'s `version` output to reconstruct `tag_name` safely)
+- [`release-please` skill](../release-please/SKILL.md) — action-output validation (the regex-validate pattern above is used when consuming `release-please-action`'s `version` output to reconstruct `tag_name` safely)

--- a/claude/skills/gh-actions/SKILL.md
+++ b/claude/skills/gh-actions/SKILL.md
@@ -15,7 +15,6 @@ description: GitHub Actions workflow safety — untrusted-context handling, safe
 - `github.event.pull_request.title` — PR title, same
 - `github.event.issue.body` / `github.event.comment.body` — issue and comment text
 - `github.head_ref` — branch name from a fork author (can contain shell metacharacters)
-- `github.event.label.name` — label names set by external contributors on public repos
 - Any `github.event.*` field that reflects contributor-supplied content
 
 ### GHA-internal contexts (generally safe)
@@ -67,7 +66,7 @@ Action outputs (e.g. from `release-please-action`) are not sanitised at source. 
     VERSION: ${{ steps.release.outputs.version }}
   run: |
     if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-      echo "Unexpected version format: $VERSION" >&2
+      printf 'Unexpected version format: %q\n' "$VERSION" >&2
       exit 1
     fi
     echo "tag_name=v$VERSION" >> "$GITHUB_OUTPUT"
@@ -139,7 +138,7 @@ Pin via the `docker://` image reference. For supply-chain immutability, pin by d
 
 Verify the digest at install time: `docker pull rhysd/actionlint:1.7.7 && docker inspect --format='{{index .RepoDigests 0}}' rhysd/actionlint:1.7.7`. Tag-pinning (`docker://rhysd/actionlint:1.7.7`) is acceptable when digest pinning is impractical, but prefer the digest form for security-sensitive lint gates.
 
-actionlint catches: undefined expressions, unknown action inputs, shell syntax errors (it runs shellcheck internally), incorrect `on:` event types, and string/number type mismatches.
+actionlint catches: undefined expressions, unknown action inputs, shell syntax errors (it invokes shellcheck if available on PATH), incorrect `on:` event types, and string/number type mismatches.
 
 ### shellcheck
 

--- a/claude/skills/github/SKILL.md
+++ b/claude/skills/github/SKILL.md
@@ -157,4 +157,4 @@ shell or by an autonomous agent invoking subprocesses:
 
 ## See Also
 
-- `gh-actions` skill — label-based override gates (RBAC-safe replacement for PR-body text markers), untrusted-context handling, and workflow lint guards
+- [`gh-actions` skill](../gh-actions/SKILL.md) — label-based override gates (RBAC-safe replacement for PR-body text markers), untrusted-context handling, and workflow lint guards

--- a/claude/skills/github/SKILL.md
+++ b/claude/skills/github/SKILL.md
@@ -154,3 +154,7 @@ shell or by an autonomous agent invoking subprocesses:
 - Amending commits during PR review (`--amend`) — stack new signed commits; squash merge makes amend pointless
 - Force-pushing (`--force`, `--force-with-lease`) — breaks reviewer context, blocked by guardrail hooks
 - Emojis in branch names or code
+
+## See Also
+
+- `gh-actions` skill — label-based override gates (RBAC-safe replacement for PR-body text markers), untrusted-context handling, and workflow lint guards

--- a/claude/skills/release-please/SKILL.md
+++ b/claude/skills/release-please/SKILL.md
@@ -293,4 +293,4 @@ with: `GitHub Actions is not permitted to create or approve pull requests`.
 
 ## See Also
 
-- `gh-actions` skill — action-output validation (regex-validate `release-please-action`'s `version` output before constructing `tag_name`; never consume `tag_name` directly from action outputs)
+- [`gh-actions` skill](../gh-actions/SKILL.md) — action-output validation (regex-validate `release-please-action`'s `version` output before constructing `tag_name`; never consume `tag_name` directly from action outputs)

--- a/claude/skills/release-please/SKILL.md
+++ b/claude/skills/release-please/SKILL.md
@@ -290,3 +290,7 @@ with: `GitHub Actions is not permitted to create or approve pull requests`.
 - **No config validation exists** — release-please does not warn about unknown or misspelled
   fields. The JSON schema is the only reference. When something doesn't work, check field
   names against the schema before investigating behaviour.
+
+## See Also
+
+- `gh-actions` skill — action-output validation (regex-validate `release-please-action`'s `version` output before constructing `tag_name`; never consume `tag_name` directly from action outputs)


### PR DESCRIPTION
New skill covering the GitHub Actions safety surface absent from the existing `github` skill.

## Contents

**Untrusted-context handling** — taxonomy of `${{ }}` contexts that are user-authored (PR body/title, issue/comment body, `head_ref`, label names from forks) vs GHA-internal (sha, event_name, token). Why `${{ }}` is text substitution into shell source, not a data binding.

**Safe interpolation patterns** — env-var indirection as the canonical pattern; regex-validating action outputs before use; heredoc/here-string sensitivity and the correct fix.

**Override-gate design** — labels vs PR-body markers (RBAC boundary, audit trail, injection surface comparison table); `on.pull_request.types` gotcha (listing types replaces the defaults — `synchronize` must be explicit); `pull_request` vs `pull_request_target` supply-chain risk.

**Workflow lint guards** — actionlint pinned via `docker://rhysd/actionlint:<tag>`; shellcheck on `.github/scripts/`; action version pinning (SHA vs tag vs `@latest`).

**9 anti-patterns** including PR-body-marker gates, `@latest` pins, consuming action outputs without validation, `pull_request_target` + PR HEAD checkout, and missing `issues: write` for comment endpoints.

## Source

Incident: klazomenai/bridge#163 (PR-body here-string caused `syntax error near unexpected token '('`). Remediation: klazomenai/bridge#164 (label gate + actionlint + lint-workflows.yml + env-var indirection throughout release-please.yml).

## Cross-references

- `github` skill: PR workflow surface (label-gate pattern now cross-referenceable)
- `release-please` skill: action-output validation is the worked example

Closes #113
